### PR TITLE
local authentication without TLS

### DIFF
--- a/docs/configure
+++ b/docs/configure
@@ -937,7 +937,12 @@ plain_virtual_exim:
         server_set_id = $auth2
 	# comment the next line out if you want to be able to authenticate
 	# without using SSL or TLS
-	server_advertise_condition = ${if eq{$tls_cipher}{}{}{*}}
+    server_advertise_condition = ${if or{\
+       {!eq{$tls_cipher}{}}\
+        {eq {$sender_host_address}{127.0.0.1}}\
+        {eq {$sender_host_address}{::1}}\
+        }\
+        {*}{}}
 
 login_virtual_exim:
         driver = plaintext
@@ -951,7 +956,12 @@ login_virtual_exim:
         server_set_id = $auth1
 	# comment the next line out if you want to be able to authenticate
 	# without using SSL or TLS
-	server_advertise_condition = ${if eq{$tls_cipher}{}{}{*}}
+	server_advertise_condition = ${if or{\
+       {!eq{$tls_cipher}{}}\
+        {eq {$sender_host_address}{127.0.0.1}}\
+        {eq {$sender_host_address}{::1}}\
+        }\
+        {*}{}}
 
 # The following authenticators use the clear password field
 # plain_login:


### PR DESCRIPTION
In response to Issue https://github.com/avleen/vexim2/issues/7 to enable local login without encryption.
