### PR TITLE
no TLS used for all IPs used by exim.

### DIFF
--- a/docs/configure
+++ b/docs/configure
@@ -939,8 +939,7 @@ plain_virtual_exim:
 	# without using SSL or TLS
     server_advertise_condition = ${if or{\
        {!eq{$tls_cipher}{}}\
-        {eq {$sender_host_address}{127.0.0.1}}\
-        {eq {$sender_host_address}{::1}}\
+       {match_ip {$sender_host_address}{@[]}}\
         }\
         {*}{}}
 
@@ -958,8 +957,7 @@ login_virtual_exim:
 	# without using SSL or TLS
 	server_advertise_condition = ${if or{\
        {!eq{$tls_cipher}{}}\
-        {eq {$sender_host_address}{127.0.0.1}}\
-        {eq {$sender_host_address}{::1}}\
+       {match_ip {$sender_host_address}{@[]}}\
         }\
         {*}{}}
 


### PR DESCRIPTION
The follow up to last submission 2cae252 due to discussion #17.
It tested it via the smtp dialog on localhost and external host with all possible IPs (127.0.0.1, ::1, real ipv4/ipv6).
