### PR TITLE
Remove spamrep

### DIFF
--- a/docs/configure
+++ b/docs/configure
@@ -770,6 +770,7 @@ begin transports
 
 remote_smtp:
   driver = smtp
+  headers_remove = X-Spam-Report:X-Spam-Score
 
 # This transport is used for local delivery to user mailboxes in traditional
 # BSD mailbox format. By default it will be run under the uid and gid of the


### PR DESCRIPTION
I don't if it makes sense to send our spam score and spam report with every outgoing mail? Other spam detection systems normally ignore other spam-reports. It makes mails only bigger.
