### PR TITLE
rewrite subject

### DIFF
--- a/docs/configure
+++ b/docs/configure
@@ -654,6 +654,14 @@ virtual_domains:
 		and domains.enabled = '1' \
 		and users.enabled = '1' \
 		and users.domain_id = domains.domain_id}}
+  headers_remove = Subject
+  headers_add = ${if >{$spam_score_int}{${lookup mysql{select users.sa_tag * 10 from users,domains \
+                where localpart = '${quote_mysql:$local_part}' \
+                and domain = '${quote_mysql:$domain}' \
+                and users.on_spamassassin = '1' \
+                and users.on_rewrite = '1' \
+                and users.domain_id=domains.domain_id }{$value}fail}}\
+                {Subject: *****SPAM***** $h_Subject:}{Subject: $h_Subject:} }
   headers_add = ${if >{$spam_score_int}{${lookup mysql{select users.sa_tag * 10 from users,domains \
   		where localpart = '${quote_mysql:$local_part}' \
 		and domain = '${quote_mysql:$domain}' \


### PR DESCRIPTION
**Work in progress**
- [ ] New db-field `on_rewrite`
- [ ] Add option into vexim-interface
- [ ] put header-rewriting in the exim-router (mailbox)
- [x] put header-rewriting in the exim-router (mail forward)

I planned that the user can decide how to handle spam:
- move to spam folder (only mailbox, there it is default)
- rewrite subject (`on_rewrite`)
- delete spam (`on_spamdrop`)

Does it make sense for you like this? @rimas-kudelis @Z3po 
ref: https://github.com/vexim/vexim2/issues/78