### PR TITLE
Adding empty-password users through a bug in validate_password()

### DIFF
--- a/vexim/config/functions.php
+++ b/vexim/config/functions.php
@@ -6,15 +6,14 @@
      * validate if password and confirmation password match.
      * They can not be empty.
      *
-     * @param   string   $clear   cleartext password
-     * @param   string   $vclear  cleartext password (for validation)
-     * @return  boolean  true if they match and contain no illegal characters
+     * @param   string   $password   cleartext password
+     * @param   string   $confirmationPassword  cleartext password (for validation)
+     * @return  boolean  true if they match
      */
-    function validate_password($clear,$vclear) 
+    function validate_password($password, $confirmationPassword)
     {
-        return ($clear === $vclear) && ($clear !== "");
+        return (is_string($password)) && ($password === $confirmationPassword) && ($password !== "");
     }
-
 
     /**
      * Check if a user already exists.

--- a/vexim/config/tests/functionsValidatePasswordTest.php
+++ b/vexim/config/tests/functionsValidatePasswordTest.php
@@ -1,0 +1,46 @@
+<?php
+	
+	class FunctionValidatePasswordTest extends PHPUnit_Framework_TestCase {
+		
+		public function setUp() {
+			require_once(__DIR__ . '/../functions.php');
+		}
+
+        public function testSendEmptyPasswords()
+        {
+            $this->assertFalse(validate_password("", ""));
+        }
+
+        public function testSendSamePasswords()
+        {
+            $this->assertTrue(validate_password("password", "password"));
+        }
+
+        public function testSendDifferentPasswords()
+        {
+            $this->assertFalse(validate_password("password", "pass"));
+        }
+
+        public function testSendNullValues()
+        {
+            $this->assertFalse(validate_password(null, null));
+        }
+
+        public function testSendBoolValues()
+        {
+            $this->assertFalse(validate_password(true, true));
+            $this->assertFalse(validate_password(false, false));
+        }
+
+        public function testSendIntegerValues()
+        {
+            $this->assertFalse(validate_password(10, 10));
+        }
+
+        public function testSendZeroValues()
+        {
+            $this->assertFalse(validate_password(0, 0));
+        }
+	}
+
+### EOF

--- a/vexim/config/tests/functionsValidatePasswordTest.php
+++ b/vexim/config/tests/functionsValidatePasswordTest.php
@@ -1,10 +1,10 @@
 <?php
 	
-	class FunctionValidatePasswordTest extends PHPUnit_Framework_TestCase {
+class FunctionValidatePasswordTest extends PHPUnit_Framework_TestCase {
 		
-		public function setUp() {
-			require_once(__DIR__ . '/../functions.php');
-		}
+	public function setUp() {
+		require_once(__DIR__ . '/../functions.php');
+	}
 
         public function testSendEmptyPasswords()
         {
@@ -41,6 +41,6 @@
         {
             $this->assertFalse(validate_password(0, 0));
         }
-	}
+}
 
 ### EOF


### PR DESCRIPTION
The latest update https://github.com/vexim/vexim2/commit/d06625b80abc6378cb4aa41c8fdbcaec03ce0d82 introduced a bug into the *validate_password()* function as it returns true for null values. 
E.g.: **siteaddsubmit.php** line **82**
**if (validate_password($_POST['clear'], $_POST['vclear']))** returns true if *clear* and *vclear* input fields have been removed from the DOM before submitting.

The patch also includes tests for the function and some small changes to the function and documentation.