### PR TITLE
Maximum messages size parameter was ignored for adminuserchange.

### DIFF
--- a/vexim/adminuserchangesubmit.php
+++ b/vexim/adminuserchangesubmit.php
@@ -15,7 +15,7 @@
   }
  
   # Fix the boolean values
-  $query = "SELECT avscan,spamassassin,pipe,uid,gid,quotas
+  $query = "SELECT avscan,spamassassin,pipe,uid,gid,quotas,maxmsgsize
     FROM domains
     WHERE domain_id=:domain_id";
   $sth = $dbh->prepare($query);
@@ -99,6 +99,12 @@
     $forwardaddr = $_POST['forwardmenu'];
   } else {
     $forwardaddr = $_POST['forward'];
+  }
+
+  if (isset($_POST['maxmsgsize']) && $row['maxmsgsize']!=='0') {
+    if ($_POST['maxmsgsize']<=0 || $_POST['maxmsgsize']>$row['maxmsgsize']) {
+      $_POST['maxmsgsize']=$row['maxmsgsize'];
+    }
   }
 
   # Prevent de-admining the last admin

--- a/vexim/userchangesubmit.php
+++ b/vexim/userchangesubmit.php
@@ -22,7 +22,11 @@
   $row = $sth->fetch();
   if ((isset($_POST['on_avscan'])) && ($row['avscan'] === '1')) {$_POST['on_avscan'] = 1;} else {$_POST['on_avscan'] = 0;}
   if ((isset($_POST['on_spamassassin'])) && ($row['spamassassin'] === '1')) {$_POST['on_spamassassin'] = 1;} else {$_POST['on_spamassassin'] = 0;}
-  if ((isset($_POST['maxmsgsize'])) && ($_POST['maxmsgsize'] > $row['maxmsgsize'])) {$_POST['maxmsgsize'] = $row['maxmsgsize'];}
+  if (isset($_POST['maxmsgsize']) && $row['maxmsgsize']!=='0') {
+    if ($_POST['maxmsgsize']<=0 || $_POST['maxmsgsize']>$row['maxmsgsize']) {
+      $_POST['maxmsgsize']=$row['maxmsgsize'];
+    }
+  }
 
   if ($_POST['realname'] !== "") {
     $query = "UPDATE users SET realname=:realname


### PR DESCRIPTION
Repaired the max-massage-size problems discovered during tests of https://github.com/vexim/vexim2/pull/100#issuecomment-166034354.

When an adminuser changed the message size for a user, the `maxmsgsize` was ignored. I added a control.

A further issue was discovered for users changing their settings (userchangesubmit), the `maxmsgsize` was working for a domain with limited massage size (`maxmsgsize>0`) but when the limit was 0 (unlimited), the user could set an individual limit.