### PR TITLE
Allow custom usernames.

### DIFF
--- a/vexim/adminaliasadd.php
+++ b/vexim/adminaliasadd.php
@@ -29,6 +29,11 @@
             <td><input name="realname" type="text" class="textfield"></td>
           </tr>
           <tr>
+            <td><?php echo _('User Name'); ?>:</td>
+            <td>
+              <input name="username" type="text" class="textfield"></td>
+          </tr>
+          <tr>
             <td><?php echo _('Address'); ?>:</td>
             <td>
               <input name="localpart" type="text" class="textfield">@

--- a/vexim/adminaliasaddsubmit.php
+++ b/vexim/adminaliasaddsubmit.php
@@ -45,7 +45,7 @@
 
   # check_user_exists() will die if a user account already exists with the same localpart and domain id
   check_user_exists(
-    $dbh,$_POST['localpart'],$_SESSION['domain_id'],'adminalias.php'
+    $dbh,$_POST['username'],$_POST['localpart'],$_SESSION['domain_id'],'adminalias.php'
   );
 
   if ((preg_match("/['@%!\/\|\" ']/",$_POST['localpart']))
@@ -73,7 +73,7 @@
     $sth = $dbh->prepare($query);
        $success = $sth->execute(array(
        ':localpart' => $_POST['localpart'],
-       ':username' => $_POST['localpart'] . '@' . $_SESSION['domain'],
+       ':username' => $_POST['username'],
        ':domain_id' => $_SESSION['domain_id'],
        ':crypt' => crypt_password($_POST['clear']),
        ':smtp' => $aliasto,

--- a/vexim/adminaliaschange.php
+++ b/vexim/adminaliaschange.php
@@ -3,7 +3,7 @@
   include_once dirname(__FILE__) . '/config/authpostmaster.php';
   include_once dirname(__FILE__) . '/config/functions.php';
   include_once dirname(__FILE__) . '/config/httpheaders.php';
-  $query = "SELECT localpart,realname,smtp,on_avscan,on_spamassassin,sa_tag,sa_refuse,spam_drop,
+  $query = "SELECT localpart,username,realname,smtp,on_avscan,on_spamassassin,sa_tag,sa_refuse,spam_drop,
     admin,enabled FROM users 	
 	WHERE user_id=:user_id AND domain_id=:domain_id AND type='alias'";
   $sth = $dbh->prepare($query);
@@ -50,6 +50,13 @@
             <td>
               <input name="realname" type="text"
               value="<?php print $row['realname']; ?>"class="textfield">
+            </td>
+          </tr>
+          <tr>
+            <td><?php echo _('User Name'); ?>:</td>
+            <td>
+              <input name="username" type="text"
+              value="<?php print $row['username']; ?>"class="textfield">
             </td>
           </tr>
           <tr>

--- a/vexim/adminfailaddsubmit.php
+++ b/vexim/adminfailaddsubmit.php
@@ -5,7 +5,7 @@
   include_once dirname(__FILE__) . '/config/httpheaders.php';
 
   check_user_exists(
-    $dbh,$_POST['localpart'],$_SESSION['domain_id'],'adminfail.php'
+    $dbh,$_POST['localpart'].'@'.$_SESSION['domain'],$_POST['localpart'],$_SESSION['domain_id'],'adminfail.php'
   );
 
   if (preg_match("/['@%!\/\| ']/",$_POST['localpart'])) {

--- a/vexim/admingroupaddsubmit.php
+++ b/vexim/admingroupaddsubmit.php
@@ -9,7 +9,7 @@
   }
 
   check_user_exists(
-    $dbh,$_POST['localpart'],$_SESSION['domain_id'],'admingroup.php'
+    $dbh,$_POST['localpart'].'@'.$_SESSION['domain'],$_POST['localpart'],$_SESSION['domain_id'],'admingroup.php'
   );
 
   $query = "INSERT INTO groups (name, domain_id)

--- a/vexim/adminuser.php
+++ b/vexim/adminuser.php
@@ -12,7 +12,7 @@
   if (!isset($_POST['searchfor'])) {
     $_POST['searchfor'] = '';
   }
-  if (!isset($_POST['field']) || ($_POST['field'] != 'localpart')) {
+  if (!isset($_POST['field']) || (($_POST['field'] != 'localpart') && ($_POST['field'] != 'username'))) {
     $_POST['field'] = 'realname';
   }
 ?>
@@ -57,6 +57,9 @@
           <option value="realname" <?php if ($_POST['field'] == 'realname') {
             echo 'selected="selected"';
           } ?>><?php echo _('User'); ?></option>
+          <option value="username" <?php if ($_POST['field'] == 'username') {
+            echo "selected=\"selected\"";
+          } ?>><?php echo _('User Name'); ?></option>
           <option value="localpart" <?php if ($_POST['field'] == 'localpart') {
             echo "selected=\"selected\"";
           } ?>><?php echo _('Email address'); ?></option>

--- a/vexim/adminuseradd.php
+++ b/vexim/adminuseradd.php
@@ -49,6 +49,12 @@
           </td>
         </tr>
         <tr>
+          <td><?php echo _('User Name'); ?>:</td>
+          <td colspan="2">
+            <input type="textfield" size="25" name="username" class="textfield">
+          </td>
+        </tr>
+        <tr>
           <td><?php echo _('Address'); ?>:</td>
           <td colspan="2">
             <input type="textfield" size="25" name="localpart"

--- a/vexim/adminuseraddsubmit.php
+++ b/vexim/adminuseraddsubmit.php
@@ -24,6 +24,8 @@
   # Strip off leading and trailing spaces
   $_POST['localpart'] = preg_replace("/^\s+/","",$_POST['localpart']);
   $_POST['localpart'] = preg_replace("/\s+$/","",$_POST['localpart']); 
+  $_POST['username'] = preg_replace("/^\s+/","",$_POST['username']);
+  $_POST['username'] = preg_replace("/\s+$/","",$_POST['username']); 
 
   # get the settings for the domain 
   $query = "SELECT avscan,spamassassin,pipe,uid,gid,quotas,maxmsgsize FROM domains 
@@ -90,7 +92,7 @@
   }
 
   check_user_exists(
-    $dbh,$_POST['localpart'],$_SESSION['domain_id'],'adminuser.php'
+    $dbh,$_POST["username"],$_POST['localpart'],$_SESSION['domain_id'],'adminuser.php'
   );
 
   if (preg_match("/^\s*$/",$_POST['realname'])) {
@@ -128,7 +130,7 @@
     $sth = $dbh->prepare($query);
     $success = $sth->execute(array(':localpart'=>$_POST['localpart'],
         ':localpart'=>$_POST['localpart'],
-        ':username'=>$_POST['localpart'].'@'.$_SESSION['domain'],
+        ':username'=>$_POST['username'],
         ':domain_id'=>$_SESSION['domain_id'],
         ':crypt'=>crypt_password($_POST['clear']),
         ':smtp'=>$smtphomepath,

--- a/vexim/adminuserchange.php
+++ b/vexim/adminuserchange.php
@@ -58,6 +58,10 @@
         </tr>
         <tr>
           <td><?php echo _('Email Address'); ?>:</td>
+          <td><?php print $row['localpart'] . '@' . $_SESSION['domain']; ?></td>
+        </tr>
+        <tr>
+          <td><?php echo _('User Name'); ?>:</td>
           <td><?php print $row['username']; ?></td>
         </tr>
         <input name="user_id" type="hidden"

--- a/vexim/config/functions.php
+++ b/vexim/config/functions.php
@@ -27,14 +27,17 @@
      * @param  string  $domain_id
      * @param  string  $page       page to return to
      */
-    function check_user_exists($dbh,$localpart,$domain_id,$page)
+    function check_user_exists($dbh,$username,$localpart,$domain_id,$page)
     {
         $query = "SELECT COUNT(*) AS c 
                   FROM   users 
-                  WHERE  localpart=:localpart
-                  AND    domain_id=:domain_id";
+                  WHERE  username=:username
+                  OR (
+                      localpart=:localpart
+                      AND    domain_id=:domain_id
+                  )";
         $sth = $dbh->prepare($query);
-        $sth->execute(array(':localpart'=>$localpart, ':domain_id'=>$domain_id));
+        $sth->execute(array(':username'=>$username, ':localpart'=>$localpart, ':domain_id'=>$domain_id));
         $row = $sth->fetch();
         if ($row['c'] != 0) 
         {

--- a/vexim/siteadd.php
+++ b/vexim/siteadd.php
@@ -31,15 +31,24 @@
             if ($_GET['type'] == "local") {
           ?>
           <tr>
-            <td><?php echo _('Domain Admin'); ?>:</td>
+            <td><?php echo _('User Name'); ?>:</td>
             <td>
-              <input name="localpart" type="text" value="postmaster"
+              <input name="username" type="text" value=""
                 class="textfield">
             </td>
             <td>
               <?php
                 echo _('The username of the domain\'s administrator account');
               ?>
+            </td>
+          </tr>
+          <tr>
+            <td><?php echo _('Domain Admin'); ?>:</td>
+            <td>
+              <input name="localpart" type="text" value="postmaster"
+                class="textfield">
+            </td>
+            <td>
             </td>
           </tr>
           <tr>

--- a/vexim/siteaddsubmit.php
+++ b/vexim/siteaddsubmit.php
@@ -109,7 +109,7 @@
             WHERE domains.domain=:domain";
         $sth = $dbh->prepare($query);
         $success = $sth->execute(array(':localpart'=>$_POST['localpart'],
-                ':username'=>$_POST['localpart'].'@'.$_POST['domain'],
+                ':username'=>$_POST['username'],
                 ':crypt'=>crypt_password($_POST['clear']),
                 ':uid'=>$uid, ':gid'=>$gid, ':smtp'=>$smtphomepath,
                 ':pop'=>$pophomepath,

--- a/vexim/userchange.php
+++ b/vexim/userchange.php
@@ -32,6 +32,7 @@
       <form name="userchange" method="post" action="userchangesubmit.php">
 	<table align="center">
 	  <tr><td><?php echo _("Name"); ?>:</td><td><input name="realname" type="text" value="<?php print $row['realname']; ?>" class="textfield"></td></tr>
+	  <tr><td><?php echo _("User Name"); ?>:</td><td><?php print $row['username']; ?></tr>
 	  <tr><td><?php echo _("Email Address"); ?>:</td><td><?php print $row['localpart']."@".$_SESSION['domain']; ?></td>
 	  <tr><td><?php echo _("Password"); ?>:</td><td><input name="clear" type="password" class="textfield"></td></tr>
 	  <tr><td><?php echo _("Verify Password"); ?>:</td><td><input name="vclear" type="password" class="textfield"></td></tr>


### PR DESCRIPTION
We typically use vexim with customers that want to upgrade their existing ancient mail system, so we want to keep the same usernames they were using and, most of the times, they use a specific schema for usernames that they want to keep for new users (and that doesn't match e-mail address), so we need to be able to select what username to use when creating a new account.
This patch allows domain admins to select which username to use for new accounts. I don't know if you may be interested in merging it upstream, so I'm pushing it and feel free to reject it if you are not interested.