### PR TITLE
Fix groups receipts

### DIFF
--- a/docs/configure
+++ b/docs/configure
@@ -701,7 +701,7 @@ virtual_dom_groups:
                                             d.domain_id = g.domain_id and g.enabled = '1' and \
                                             g.name = '${quote_mysql:$local_part}'}}} \
                  {$sender_address} \
-                 {${lookup mysql{select u.username \
+                 {${lookup mysql{select concat_ws('@', localpart, d.domain) \
                                  from domains d, groups g, group_contents c, users u \
                                  where d.enabled = '1' and d.domain = '${quote_mysql:$domain}' and \
                                        d.domain_id = g.domain_id and g.name = '${quote_mysql:$local_part}' and \
@@ -710,7 +710,7 @@ virtual_dom_groups:
                                        d.domain_id = u.domain_id and u.enabled = '1' \
 				       and u.username = '${quote_mysql:$sender_address}' }}}}
   data = ${lookup mysql{ \
-            select u.username \
+            select concat_ws('@', localpart, d.domain) \
             from domains d, groups g, group_contents c, users u \
             where d.enabled     = '1'           and \
                   d.domain      = '${quote_mysql:$domain}'   and \

--- a/docs/configure
+++ b/docs/configure
@@ -701,7 +701,7 @@ virtual_dom_groups:
                                             d.domain_id = g.domain_id and g.enabled = '1' and \
                                             g.name = '${quote_mysql:$local_part}'}}} \
                  {$sender_address} \
-                 {${lookup mysql{select concat_ws('@', localpart, d.domain) \
+                 {${lookup mysql{select concat_ws('@', u.localpart, d.domain) \
                                  from domains d, groups g, group_contents c, users u \
                                  where d.enabled = '1' and d.domain = '${quote_mysql:$domain}' and \
                                        d.domain_id = g.domain_id and g.name = '${quote_mysql:$local_part}' and \
@@ -710,7 +710,7 @@ virtual_dom_groups:
                                        d.domain_id = u.domain_id and u.enabled = '1' \
 				       and u.username = '${quote_mysql:$sender_address}' }}}}
   data = ${lookup mysql{ \
-            select concat_ws('@', localpart, d.domain) \
+            select concat_ws('@', u.localpart, d.domain) \
             from domains d, groups g, group_contents c, users u \
             where d.enabled     = '1'           and \
                   d.domain      = '${quote_mysql:$domain}'   and \

--- a/docs/debian-conf.d/router/250_vexim_virtual_domains
+++ b/docs/debian-conf.d/router/250_vexim_virtual_domains
@@ -95,7 +95,7 @@ virtual_dom_groups:
                                             d.domain_id = g.domain_id and g.enabled = '1' and \
                                             g.name = '${quote_mysql:$local_part}'}}} \
                  {$sender_address} \
-                 {${lookup mysql{select concat_ws('@', localpart, d.domain) \
+                 {${lookup mysql{select concat_ws('@', u.localpart, d.domain) \
                                  from domains d, groups g, group_contents c, users u \
                                  where d.enabled = '1' and d.domain = '${quote_mysql:$domain}' and \
                                        d.domain_id = g.domain_id and g.name = '${quote_mysql:$local_part}' and \
@@ -104,7 +104,7 @@ virtual_dom_groups:
                                        d.domain_id = u.domain_id and u.enabled = '1' \
                                        and u.username = '${quote_mysql:$sender_address}' }}}}
   data = ${lookup mysql{ \
-            select concat_ws('@', localpart, d.domain) \
+            select concat_ws('@', u.localpart, d.domain) \
             from domains d, groups g, group_contents c, users u \
             where d.enabled     = '1'           and \
                   d.domain      = '${quote_mysql:$domain}'   and \

--- a/docs/debian-conf.d/router/250_vexim_virtual_domains
+++ b/docs/debian-conf.d/router/250_vexim_virtual_domains
@@ -95,7 +95,7 @@ virtual_dom_groups:
                                             d.domain_id = g.domain_id and g.enabled = '1' and \
                                             g.name = '${quote_mysql:$local_part}'}}} \
                  {$sender_address} \
-                 {${lookup mysql{select u.username \
+                 {${lookup mysql{select concat_ws('@', localpart, d.domain) \
                                  from domains d, groups g, group_contents c, users u \
                                  where d.enabled = '1' and d.domain = '${quote_mysql:$domain}' and \
                                        d.domain_id = g.domain_id and g.name = '${quote_mysql:$local_part}' and \
@@ -104,7 +104,7 @@ virtual_dom_groups:
                                        d.domain_id = u.domain_id and u.enabled = '1' \
                                        and u.username = '${quote_mysql:$sender_address}' }}}}
   data = ${lookup mysql{ \
-            select u.username \
+            select concat_ws('@', localpart, d.domain) \
             from domains d, groups g, group_contents c, users u \
             where d.enabled     = '1'           and \
                   d.domain      = '${quote_mysql:$domain}'   and \

--- a/vexim/admingroupchange.php
+++ b/vexim/admingroupchange.php
@@ -75,7 +75,7 @@
         <tr>
           <td colspan="2"> 
             <?php
-              $query = "SELECT u.realname, u.username, u.enabled, c.member_id
+              $query = "SELECT u.realname, u.localpart, u.enabled, c.member_id
                 FROM users u, group_contents c
                 WHERE u.user_id=c.member_id and c.group_id=:group_id
                 ORDER BY u.enabled desc, u.realname asc";
@@ -106,7 +106,7 @@
                   </a>
                 </td>
                 <td><?php echo $row['realname']; ?></td>
-                <td><?php echo $row['username']; ?></td>
+                <td><?php echo $row['localpart'].'@'.$_SESSION['domain']; ?></td>
                 <td>
                   <?php
                     if($row['enabled']='1') {
@@ -143,7 +143,7 @@
               <select name="usertoadd">
                 <option selected value=""></option>
                 <?php
-                  $query = "SELECT realname, username, user_id FROM users
+                  $query = "SELECT realname, localpart, user_id FROM users
                     WHERE enabled='1' AND domain_id=:domain_id AND type!='fail'
                     ORDER BY realname, username, type desc";
                   $sth = $dbh->prepare($query);
@@ -152,7 +152,7 @@
                 ?>
                   <option value="<?php echo $row['user_id']; 
 					?>"><?php echo $row['realname']; 
-					?>(<?php echo $row['username']; ?>)</option>
+					?> (<?php echo $row['localpart'].'@'.$_SESSION['domain']; ?>)</option>
                 <?php 
                   }
                 ?>


### PR DESCRIPTION
If you are using a user table where the username of each user is not their e-mail address (for example #106), groups won't work because provided exim configuration resolves group addresses to the usernames of their members, instead of their e-mail addresses. This works when their usernames are their e-mail addresses, but will fail otherwise.
This patch also fixes forms that assume that username = e-mail address to correctly show e-mail addresses.