### PR TITLE
Add die()-argument

### DIFF
--- a/vexim/adminuserdelete.php
+++ b/vexim/adminuserdelete.php
@@ -44,6 +44,7 @@ if ($_GET['confirm'] == '1') {
   } else {
     header ("Location: adminuser.php?faildeleted={$_GET['localpart']}");
   }
+  die;
 } else if ($_GET['confirm'] == "cancel") {                 
     header ("Location: adminuser.php?faildeleted={$_GET['localpart']}");
     die;                                                      


### PR DESCRIPTION
After an account is deleted and the redirection-header() is set, there is no point to continue to run the script which show the confirmation message.