### PR TITLE
Can't specify sa-settings when SA is disabled for domain.

### DIFF
--- a/vexim/adminaliaschangesubmit.php
+++ b/vexim/adminaliaschangesubmit.php
@@ -91,9 +91,9 @@
     ':admin'=>$_POST['admin'],
     ':on_avscan'=>$_POST['on_avscan'],
     ':on_spamassassin'=>$_POST['on_spamassassin'],
-    ':sa_tag'=>$_POST['sa_tag'],
-    ':sa_refuse'=>$_POST['sa_refuse'],
-    ':spam_drop'=>$_POST['spam_drop'],
+    ':sa_tag'=>(isset($_POST['sa_tag']) ? $_POST['sa_tag'] : 0),
+    ':sa_refuse'=>(isset($_POST['sa_refuse']) ? $_POST['sa_refuse'] : 0),
+    ':spam_drop'=>(isset($_POST['spam_drop']) ? $_POST['spam_drop'] : 0),
     ':enabled'=>$_POST['enabled'],
     ':user_id'=>$_POST['user_id'],
     ':domain_id'=>$_SESSION['domain_id']


### PR DESCRIPTION
`adminaliaschangesubmit.php` needs the changes made here https://github.com/vexim/vexim2/commit/df0bfcac678713f009c909aa37d9515f91f08276 as well.