### PR TITLE
Smaller fixes on new catchall and userchange

### DIFF
--- a/vexim/admincatchallsubmit.php
+++ b/vexim/admincatchallsubmit.php
@@ -7,9 +7,9 @@
     header ("Location: adminalias.php?invalidforward=".htmlentities($_POST['smtp']));
     die;
   }
-  $query = "DELETE FROM users WHERE user_id=:user_id AND domain_id=:domain_id AND type='catch'";
+  $query = "DELETE FROM users WHERE domain_id=:domain_id AND type='catch'";
   $sth = $dbh->prepare($query);
-  $success = $sth->execute(array(':user_id'=>$_POST['user_id'], ':domain_id'=>$_SESSION['domain_id']));
+  $success = $sth->execute(array(':domain_id'=>$_SESSION['domain_id']));
   if(!$success) {
     header ("Location: adminalias.php?failupdated=Catchall");
   } else {

--- a/vexim/userchange.php
+++ b/vexim/userchange.php
@@ -23,7 +23,7 @@
     <title><?php echo _("Virtual Exim") . ": " . _("Manage Users"); ?></title>
     <link rel="stylesheet" href="style.css" type="text/css">
   </head>
-  <body onLoad="document.userchange.realname.focus()">
+  <body onLoad="document.forms[0].elements[0].focus()">
     <?php include dirname(__FILE__) . "/config/header.php"; ?>
     <div id="menu">
       <a href="logout.php"><?php echo _("Logout"); ?></a><br>
@@ -161,7 +161,7 @@
 	  </select></td>
 	    <td><input name="blockval" type="text" size="25" class="textfield">
 	  <input name="color" type="hidden" value="black"></td></tr>
-  	  <tr><td><input name="submit" type="submit" value="Submit"></td></tr>
+  	  <tr><td></td><td class="button"><input name="submit" type="submit" value="Submit"></td></tr>
     </table>
     </form>
     <table align="center">

--- a/vexim/userchangesubmit.php
+++ b/vexim/userchangesubmit.php
@@ -3,18 +3,21 @@
   include_once dirname(__FILE__) . "/config/authuser.php";
   include_once dirname(__FILE__) . "/config/functions.php";
   include_once dirname(__FILE__) . "/config/httpheaders.php";
-  if (isset($_POST['on_vacation'])) {$_POST['on_vacation'] = 1;} else {$_POST['on_vacation'] = 0;}
+
+  $_POST['on_vacation'] = isset($_POST['on_vacation']) ? 1 : 0;
   if (isset($_POST['on_forward'])) {
     $_POST['on_forward'] = 1;
     if(!filter_var($_POST['forward'], FILTER_VALIDATE_EMAIL)) {
       header ("Location: userchange.php?invalidforward=".htmlentities($_POST['forward']));
       die;
     }
+    $_POST['unseen'] = isset($_POST['unseen']) ? 1 : 0;
   } else {
     $_POST['on_forward'] = 0;
     $_POST['forward']='';
+    $_POST['unseen']=0;
   }
-  if (isset($_POST['unseen']) && $_POST['on_forward']==1) {$_POST['unseen'] = 1;} else {$_POST['unseen'] = 0;}
+
   # Do some checking, to make sure the user is ALLOWED to make these changes
   $query = "SELECT avscan,spamassassin,maxmsgsize from domains WHERE domain_id=:domain_id";
   $sth = $dbh->prepare($query);
@@ -28,7 +31,7 @@
     }
   }
 
-  if (isset($_POST['realname'])) {
+  if (isset($_POST['realname']) && $_POST['realname']!=="") {
     $query = "UPDATE users SET realname=:realname
 		WHERE user_id=:user_id";
     $sth = $dbh->prepare($query);

--- a/vexim/userchangesubmit.php
+++ b/vexim/userchangesubmit.php
@@ -14,7 +14,7 @@
     $_POST['on_forward'] = 0;
     $_POST['forward']='';
   }
-  if (isset($_POST['unseen'])) {$_POST['unseen'] = 1;} else {$_POST['unseen'] = 0;}
+  if (isset($_POST['unseen']) && $_POST['on_forward']==1) {$_POST['unseen'] = 1;} else {$_POST['unseen'] = 0;}
   # Do some checking, to make sure the user is ALLOWED to make these changes
   $query = "SELECT avscan,spamassassin,maxmsgsize from domains WHERE domain_id=:domain_id";
   $sth = $dbh->prepare($query);
@@ -28,7 +28,7 @@
     }
   }
 
-  if ($_POST['realname'] !== "") {
+  if (isset($_POST['realname'])) {
     $query = "UPDATE users SET realname=:realname
 		WHERE user_id=:user_id";
     $sth = $dbh->prepare($query);
@@ -50,6 +50,12 @@
       header ("Location: userchange.php?badpass");
       die;
     }
+  }
+
+#If the realname was changed in the upper form, don't run the rest of the script
+  if (isset($_POST['realname'])) {
+    header ("Location: userchange.php?userupdated");
+    die;
   }
 
   if (isset($_POST['vacation']) && is_string($_POST['vacation'])) {


### PR DESCRIPTION
Some smaller fixes:

* New catchall, we used `$_POST[user_id]` even though this does not exist
* userchange: when only the `realname` is changed in the upper form, the script runs the other updates and creates errors on non existing `$_POST[value]`-variables.
* userchange: option to `store forwarded mail locally` makes only sense when forwarding is active.