### PR TITLE
Always allow siteadmin to login

### DIFF
--- a/vexim/login.php
+++ b/vexim/login.php
@@ -63,13 +63,15 @@
     header ('Location: index.php?login=failed');
     die();
   }
-  if (($row['userenabled'] === '0')) {
-    header ('Location: index.php?userdisabled');
-    die();
-  }
-  if (($row['domainenabled'] === '0')) {
-    header ('Location: index.php?domaindisabled');
-    die();
+  if($row['localpart']!=='siteadmin') {
+    if (($row['userenabled'] === '0')) {
+      header ('Location: index.php?userdisabled');
+      die();
+    }
+    if (($row['domainenabled'] === '0')) {
+      header ('Location: index.php?domaindisabled');
+      die();
+    }
   }
 
   # populate session variables from what was retrieved from the database (NOT what they posted)


### PR DESCRIPTION
`userenabled` is not queried in https://github.com/vexim/vexim2/blob/master/vexim/login.php#L17 so `$row[userenabled]` doesn't exist. We could add this to the SQL queries but it why should someone disable siteadmin? Via vexim, there is no way to do (or undo) this.