### PR TITLE
Updated some field lengths. Fixes #108.

### DIFF
--- a/setup/create_db.pl
+++ b/setup/create_db.pl
@@ -183,8 +183,8 @@ sub create_mysqldb {
 
 sub create_mysqltables {
    $mydbh->do("CREATE TABLE IF NOT EXISTS $databasename.domains (domain_id mediumint(8) unsigned NOT NULL auto_increment,
-	domain varchar(64) NOT NULL default '',
-	maildir varchar(128) NOT NULL default '',
+	domain varchar(255) NOT NULL default '',
+	maildir varchar(4096) NOT NULL default '',
 	uid smallint(5) unsigned NOT NULL default '$uid',
 	gid smallint(5) unsigned NOT NULL default '$gid',
 	max_accounts int(10) unsigned NOT NULL default '0',
@@ -206,13 +206,13 @@ sub create_mysqltables {
    
   $mydbh->do("CREATE TABLE IF NOT EXISTS $databasename.users (user_id int(10) unsigned NOT NULL auto_increment,
 	domain_id mediumint(8) unsigned NOT NULL,
-	localpart varchar(192) NOT NULL default '',
+	localpart varchar(64) NOT NULL default '',
 	username varchar(255) NOT NULL default '',
 	crypt varchar(255) default NULL,
 	uid smallint(5) unsigned NOT NULL default '65534',
 	gid smallint(5) unsigned NOT NULL default '65534',
-	smtp varchar(255) default NULL,
-	pop varchar(255) default NULL,
+	smtp varchar(4096) default NULL,
+	pop varchar(4096) default NULL,
 	type enum('local','alias','catch', 'fail', 'piped', 'admin', 'site') NOT NULL default 'local',
 	admin bool NOT NULL default '0',
 	on_avscan bool NOT NULL default '0',
@@ -242,13 +242,13 @@ sub create_mysqltables {
   	domain_id mediumint(8) unsigned NOT NULL,
 	user_id int(10) unsigned default NULL,
 	blockhdr varchar(192) NOT NULL default '',
-	blockval varchar(192) NOT NULL default '',
+	blockval varchar(255) NOT NULL default '',
 	color varchar(8) NOT NULL default '',
 	PRIMARY KEY (block_id))") or die "Could not create table blocklists in the vexim database!";
   print "Created blocklists table\n";
    
   $mydbh->do("CREATE TABLE IF NOT EXISTS $databasename.domainalias (domain_id mediumint(8) unsigned NOT NULL,
-  	alias varchar(64))") or die "Could not create table domainalias in the vexim database!";
+  	alias varchar(255))") or die "Could not create table domainalias in the vexim database!";
   print "Created domainalias table\n";
   
   $mydbh->do("CREATE TABLE IF NOT EXISTS $databasename.group_contents (group_id int(10) NOT NULL,

--- a/setup/mysql.sql
+++ b/setup/mysql.sql
@@ -12,8 +12,8 @@ DROP TABLE IF EXISTS `vexim`.`domains`;
 CREATE TABLE IF NOT EXISTS `vexim`.`domains`
 (
     domain_id      mediumint(8)  unsigned  NOT NULL  auto_increment,
-	domain           varchar(64)             NOT NULL  default '',
-	maildir          varchar(128)            NOT NULL  default '',
+	domain           varchar(255)            NOT NULL  default '',
+	maildir          varchar(4096)           NOT NULL  default '',
 	uid              smallint(5)   unsigned  NOT NULL  default 'CHANGE',
 	gid              smallint(5)   unsigned  NOT NULL  default 'CHANGE',
 	max_accounts     int(10)       unsigned  NOT NULL  default '0', 
@@ -40,13 +40,13 @@ CREATE TABLE IF NOT EXISTS `vexim`.`users`
 (
     user_id          int(10)       unsigned  NOT NULL  auto_increment,
 	domain_id        mediumint(8)  unsigned  NOT NULL,
-	localpart        varchar(192)            NOT NULL  default '',
+	localpart        varchar(64)             NOT NULL  default '',
 	username         varchar(255)            NOT NULL  default '',
 	crypt            varchar(255)                       default NULL,
 	uid              smallint(5)   unsigned  NOT NULL  default '65534',
 	gid              smallint(5)   unsigned  NOT NULL  default '65534',
-	smtp             varchar(255)                      default NULL,
-	pop              varchar(255)                      default NULL,
+	smtp             varchar(4096)                     default NULL,
+	pop              varchar(4096)                     default NULL,
 	type             enum('local', 'alias', 
                           'catch', 'fail', 
                           'piped', 'admin', 
@@ -85,7 +85,7 @@ CREATE TABLE IF NOT EXISTS `vexim`.`blocklists`
   	domain_id        mediumint(8)  unsigned  NOT NULL,
 	user_id          int(10)       unsigned            default NULL,
 	blockhdr         varchar(192)            NOT NULL  default '',
-	blockval         varchar(192)            NOT NULL  default '',
+	blockval         varchar(255)            NOT NULL  default '',
 	color            varchar(8)              NOT NULL  default '',
 	PRIMARY KEY (block_id)
 );
@@ -97,7 +97,7 @@ CREATE TABLE IF NOT EXISTS `vexim`.`blocklists`
 CREATE TABLE IF NOT EXISTS `vexim`.`domainalias` 
 (
     domain_id        mediumint(8)  unsigned  NOT NULL,
-	alias varchar(64)
+	alias varchar(255)
 );
 
 --

--- a/setup/pgsql.sql
+++ b/setup/pgsql.sql
@@ -1,7 +1,7 @@
 CREATE DATABASE vexim WITH ENCODING 'UTF8';
 CREATE TABLE domains (domain_id SERIAL PRIMARY KEY,
-	domain varchar(64) UNIQUE NOT NULL,
-	maildir varchar(128) NOT NULL default '',
+	domain varchar(255) UNIQUE NOT NULL,
+	maildir varchar(4096) NOT NULL default '',
 	uid int NOT NULL default '65534' CHECK(uid BETWEEN 1 AND 65535),
 	gid int NOT NULL default '65534' CHECK(uid BETWEEN 1 AND 65535),
 	max_accounts int NOT NULL default '0',
@@ -18,13 +18,13 @@ CREATE TABLE domains (domain_id SERIAL PRIMARY KEY,
 	sa_refuse int NOT NULL default '0' CHECK(sa_refuse > -1));
 CREATE TABLE users (user_id SERIAL PRIMARY KEY,
 	domain_id int NOT NULL,
-	localpart varchar(192) NOT NULL,
+	localpart varchar(64) NOT NULL,
 	username varchar(255) NOT NULL,
 	crypt varchar(255) default NULL,
 	uid int NOT NULL default '65534' CHECK(uid BETWEEN 1 AND 65535),
 	gid int NOT NULL default '65534' CHECK(uid BETWEEN 1 AND 65535),
-	smtp varchar(255) default NULL,
-	pop varchar(255) default NULL,
+	smtp varchar(4096) default NULL,
+	pop varchar(4096) default NULL,
 	type varchar(8) CHECK(type in ('local','alias','catch', 'fail', 'piped', 'admin', 'site')) NOT NULL,
 	admin smallint NOT NULL default '0',
 	on_avscan smallint NOT NULL default '0',
@@ -50,11 +50,11 @@ CREATE TABLE blocklists (block_id SERIAL PRIMARY KEY,
 	localpart varchar(192) NOT NULL,
 	user_id int NOT NULL,
 	blockhdr varchar(192) NOT NULL default '',
-	blockval varchar(192) NOT NULL default '',
+	blockval varchar(255) NOT NULL default '',
 	color varchar(8) NOT NULL default '');
 CREATE INDEX blocklists_user_id_key ON blocklists (user_id);
 CREATE TABLE domainalias (domain_id int NOT NULL,
-        alias varchar(64));
+        alias varchar(255));
 CREATE TABLE groups (
         id                  SERIAL PRIMARY KEY,
         domain_id           int CHECK(domain_id > -1),


### PR DESCRIPTION
New limits are:
- Filesystem paths: 4096 characters (current default limit of the Linux kernel)
- Domain names: 255 characters. Practical limit is in fact 252, but nevermind
- Localparts: 64 characters (per RFC3696, Errata #1690)