### PR TITLE
Respect domain-wide settings for spamassassin and avscan

### DIFF
--- a/docs/configure
+++ b/docs/configure
@@ -508,6 +508,7 @@ ditch_malware:
 		                where localpart = '${quote_mysql:$local_part}' \
 		                and domain = '${quote_mysql:$domain}' \ 
 		                and users.on_avscan = '1' \
+                                and domains.avscan = '1' \
 		                and users.domain_id=domains.domain_id}}}{1} }} {yes}{no} }
 
 # spam drop router
@@ -519,6 +520,7 @@ ditch_spam_drop:
         where localpart = '${quote_mysql:$local_part}' \
         and domain = '${quote_mysql:$domain}' \
         and users.on_spamassassin = '1' \
+        and domains.spamassassin = '1' \
         and users.spam_drop = '1' \
         and users.domain_id=domains.domain_id \
         and users.sa_refuse > 0 }{$value}fail}} {yes}{no}}
@@ -540,6 +542,7 @@ ditch_spam:
         where localpart = '${quote_mysql:$local_part}' \ 
         and domain = '${quote_mysql:$domain}' \ 
         and users.on_spamassassin = '1' \ 
+        and domains.spamassassin = '1' \
         and users.spam_drop = '0' \
         and users.on_forward = '0' \
         and users.type = 'local' \
@@ -653,8 +656,9 @@ virtual_domains:
   driver = redirect
   domains = +local_domains
   address_data = ${lookup mysql{\
-        select smtp, users.sa_tag*10 AS sa_tag, users.on_spamassassin AS on_spamassassin, \
-        users.uid AS uid, users.gid AS gid, quota from users,domains \
+        select smtp, users.sa_tag*10 AS sa_tag, users.on_spamassassin AND domains.spamassassin AS on_spamassassin, \
+        users.uid AS uid, users.gid AS gid, quota \
+        from users,domains \
         where localpart = '${quote_mysql:$local_part}' \
                 and domain = '${quote_mysql:$domain}' \
                 and domains.enabled = '1' \

--- a/docs/debian-conf.d/router/249_vexim_ditch_routers
+++ b/docs/debian-conf.d/router/249_vexim_ditch_routers
@@ -39,6 +39,7 @@ ditch_malware:
         where localpart = '${quote_mysql:$local_part}' \
         and domain = '${quote_mysql:$domain}' \ 
         and users.on_avscan = '1' \
+        and domains.avscan = '1' \
         and users.domain_id=domains.domain_id}}}{1} }} {yes}{no} }
 
 # spam drop router
@@ -50,6 +51,7 @@ ditch_spam_drop:
         where localpart = '${quote_mysql:$local_part}' \
         and domain = '${quote_mysql:$domain}' \
         and users.on_spamassassin = '1' \
+        and domains.spamassassin = '1' \
         and users.spam_drop = '1' \
         and users.domain_id=domains.domain_id \
         and users.sa_refuse > 0 }{$value}fail}} {yes}{no}}
@@ -71,6 +73,7 @@ ditch_spam:
         where localpart = '${quote_mysql:$local_part}' \ 
         and domain = '${quote_mysql:$domain}' \ 
         and users.on_spamassassin = '1' \ 
+        and domains.spamassassin = '1' \
         and users.spam_drop = '0' \
         and users.on_forward = '0' \
         and users.type = 'local' \

--- a/docs/debian-conf.d/router/250_vexim_virtual_domains
+++ b/docs/debian-conf.d/router/250_vexim_virtual_domains
@@ -42,8 +42,9 @@ virtual_domains:
   driver = redirect
   domains = +local_domains
   address_data = ${lookup mysql{\
-        select smtp, users.sa_tag*10 AS sa_tag, users.on_spamassassin AS on_spamassassin, \
-        users.uid AS uid, users.gid AS gid, quota from users,domains \
+        select smtp, users.sa_tag*10 AS sa_tag, users.on_spamassassin AND domains.spamassassin AS on_spamassassin, \
+        users.uid AS uid, users.gid AS gid, quota \
+        from users,domains \
         where localpart = '${quote_mysql:$local_part}' \
                 and domain = '${quote_mysql:$domain}' \
                 and domains.enabled = '1' \


### PR DESCRIPTION
Only respect the sa/av-settings of a user if it was enabled for the domain.