### PR TITLE
Add reverse lookup

### DIFF
--- a/docs/configure
+++ b/docs/configure
@@ -91,6 +91,17 @@ VEXIM_LOCALPART_SUFFIX = +*
 # 'headers_remove' behavior. See https://github.com/vexim/vexim2/pull/102 .
 #OLD_HEADERS_REMOVE = yes
 
+# Reverse DNS checks can be efficient to fight spam. It checks if host name associated to the ip address matches
+# the sender_host_name (for properly configured mail servers this should be the case). However, there are some
+# downsides: DNS checks slow down the delivery process, DNS problems can result in rejected mails. You should
+# consider using a caching DNS server such as unbound on your host.
+# If the rule is activated, failed rDNS entries will only be logged to your exim-logfile (test mode). If you want
+# to reject mails directly, go to the vexim-acl-check-rcpt.conf and replace this line:
+#  warn message           = Warning - Reverse DNS lookup failed for host $sender_host_address.
+# by:
+#  deny message           = Warning - Reverse DNS lookup failed for host $sender_host_address.
+#CHECK_RCPT_REVERSE_DNS = yes
+
 #Debian: hide mysql_servers = localhost::(/var/run/mysqld/mysqld.sock)/vexim/vexim/CHANGE
 #hide mysql_servers = localhost::(/tmp/mysql.sock)/vexim/vexim/CHANGE
 #hide pgsql_servers = localhost/vexim/vexim/CHANGE

--- a/docs/vexim-acl-check-rcpt.conf
+++ b/docs/vexim-acl-check-rcpt.conf
@@ -51,9 +51,12 @@
 #                          where domain = '${quote_mysql:$domain}' \
 #                          and spamassassin='1'}}}{1} {yes}{no}}
 #          !acl          = spf_rcpt_acl
-  deny message           = Warning - Reverse DNS lookup failed for host $sender_host_address.
+
+.ifdef CHECK_RCPT_REVERSE_DNS
+  warn message           = Warning - Reverse DNS lookup failed for host $sender_host_address.
          !authenticated  = *
          !verify         = reverse_host_lookup
+.endif
 
   deny    message       = DNSBL listed at $dnslist_domain\n$dnslist_text
           dnslists      = zen.spamhaus.org:list.dsbl.org

--- a/docs/vexim-acl-check-rcpt.conf
+++ b/docs/vexim-acl-check-rcpt.conf
@@ -51,6 +51,9 @@
 #                          where domain = '${quote_mysql:$domain}' \
 #                          and spamassassin='1'}}}{1} {yes}{no}}
 #          !acl          = spf_rcpt_acl
+  deny message           = Warning - Reverse DNS lookup failed for host $sender_host_address.
+         !authenticated  = *
+         !verify         = reverse_host_lookup
 
   deny    message       = DNSBL listed at $dnslist_domain\n$dnslist_text
           dnslists      = zen.spamhaus.org:list.dsbl.org


### PR DESCRIPTION
Only accept mail from servers with correct reverse DNS settings.

A correct rDNS is required as major mail servers reject mails from servers without one (e.g. gmail).