### PR TITLE
Bring back message limit for calls to SpamAssassin

### DIFF
--- a/docs/vexim-acl-check-content.conf
+++ b/docs/vexim-acl-check-content.conf
@@ -23,9 +23,10 @@
   # deny  message = This message matches a blacklisted regular expression ($regex_match_string)
   #      regex = [Vv] *[Ii] *[Aa] *[Gg] *[Rr] *[Aa]
   
-  # Mails larger than 100 KB are accepted without spam-checking to save resources.
-  # Typical Spam has only a few KB in size.
-  #accept  condition = ${if >={$message_size}{100k}{yes}{no}}
+  # Mails larger than 300 KB are accepted without spam-checking to save resources.
+  # Message scanning time grows exponentially in the size of the message and goes timeout
+  # after 2~5 minutes, while typical spam has only a few KB in size.
+  accept  condition = ${if >={$message_size}{300k}{yes}{no}}
 
   # Reject mails with more than 15 spam-points. This is a system-wide setting and does not respect
   # individual user settings!


### PR DESCRIPTION
Re-enable by default the 'accept' ACL clause which skips spam-detection scanning via SpamAssassin for large messages (300 KB). Email scan in this case has a considerable risk to be wastefully killed by scanning timeout, since processing time grows exponentially w.r.t. size, and very little probability of being successful, since most of spam is under 10 KB.

The setting was disabled in commit f8c2c6dc7f982e5d2142586d38c1d6c002f2f2d0 and merged in pull request #24, where a thorough discussion on the subject can be found.