### PR TITLE
sort alias-destination alphabetically

### DIFF
--- a/vexim/siteadd.php
+++ b/vexim/siteadd.php
@@ -174,7 +174,7 @@
             <td colspan="2">
               <select name="aliasdest" type="text" class="textfield">
                 <?php
-                  $query = 'SELECT domain_id, domain FROM domains WHERE type="local"';
+                  $query = 'SELECT domain_id, domain FROM domains WHERE type="local" ORDER BY domain';
                   $sth = $dbh->prepare($query);
                   $sth->execute();
                   while ($row = $sth->fetch()) {


### PR DESCRIPTION
If you add an alias domain, you have to choose from a list of existing domains. This list was unsorted (or by domain_id). It's better to have a alphabetical list.