### PR TITLE
Set empty realname to localpart

### DIFF
--- a/vexim/adminuseraddsubmit.php
+++ b/vexim/adminuseraddsubmit.php
@@ -98,8 +98,7 @@
   );
 
   if (preg_match("/^\s*$/",$_POST['realname'])) {
-    header('Location: adminuser.php?blankname=yes');
-    die;
+    $_POST['realname']=$_POST['localpart'];
   }
 
   if (preg_match("/['@%!\/\| ']/",$_POST['localpart'])

--- a/vexim/config/header.php
+++ b/vexim/config/header.php
@@ -55,8 +55,6 @@
     printf (_("-- %s contains invalid characters."), $_GET['badname']);
   } else if (isset($_GET['badpass'])) {
     printf (_("-- Account %s could not be added. Your passwords were blank, do not match, or contain illegal characters: ' \" ` or ;"), $_GET['badpass']);
-  } else if (isset($_GET['blankname'])) {
-    print   _("-- You can not specify a blank realname.");
   } else if (isset($_GET['failadded'])) {
     printf (_("-- %s could not be added."), $_GET['failadded']);
   } else if (isset($_GET['failaddeddomerr'])) {


### PR DESCRIPTION
If you forget to set a `realname` for a new account, its creation will fail. I think this is a bad behavior because this setting is not critical to have a working configuration and furthermore, you can easily add a realname later. To avoid an empty value, the `realname` is set to the `localpart` of the new mail account.