### PR TITLE
Add option to block mail with zip files that contain supicious file e…

### DIFF
--- a/docs/configure
+++ b/docs/configure
@@ -157,6 +157,10 @@ acl_smtp_data = acl_check_content
 
 acl_smtp_helo = acl_check_helo
 
+# This ACL can be used to refuse certain file extension in ZIP files
+
+#acl_smtp_mime = acl_check_mime
+
 # This configuration variable defines the virus scanner that is used with
 # the 'malware' ACL condition of the exiscan acl-patch. If you do not use
 # virus scanning, leave it commented. Please read doc/exiscan-acl-readme.txt
@@ -389,6 +393,25 @@ acl_check_rcpt:
 
   deny    message       = relay not permitted
 
+# Check zip files for suspicious mail extensions
+# http://www.gossamer-threads.com/lists/exim/users/98336#98336
+
+#acl_check_mime:
+#
+#  deny message = A .zip attachment contains a Windows-executable file - \
+#                blocked because we are afraid of new viruses \
+#                not recognized [yet] by antiviruses.
+#  condition = ${if match{$mime_filename}{\N(?i)\.zip$\N}}
+#  condition = ${if def:sender_host_address}
+#  !authenticated = *
+#  decode = default
+#  log_message = forbidden binary in attachment: filename=$mime_filename, \
+#  recipients=$recipients
+#  condition = ${if match{${run{/usr/bin/unzip -l \
+#        $mime_decoded_filename}}}\
+#        {\N(?i)\.(exe|com|ade|adep|adp|bas|bat|chm|cmd|cnf|com|cpl|crt|dll|hlp|hta|inf|ins|isp|js|jse|lnk|mad|maf|mag|mam|maq|mar|mas|matmav|maw|ocx|pcd|pif|reg|scf|scr|sct|vbe|vbs|wsc|wsf|wsh|url|xnk)\n\N}}
+#
+#  accept
 
 # This access control list is used for content scanning with the exiscan-acl
 # patch. You must also uncomment the entry for acl_smtp_data (scroll up),


### PR DESCRIPTION
…xtensions

Over the last weeks, there were a lot of spam mails with contagious attachments. Many were hidden in zip-files and if you don't want to block zip-attachments in general, you can block certain file-extensions of files within the zip archive. I implemented this solution:
http://www.gossamer-threads.com/lists/exim/users/98336#98336

It is turned off by default.