### PR TITLE
spamtrap/honeypot, backscatterer

### DIFF
--- a/docs/vexim-acl-check-rcpt.conf
+++ b/docs/vexim-acl-check-rcpt.conf
@@ -1,3 +1,18 @@
+# spamtrap write sender IP to BL file when receiving messages to special
+# adresses defined in the file 'CONFDIR/spamtrap_receiver'
+deny
+  message = ${run{/bin/bash -c "/bin/echo $sender_host_address >> /etc/exim4/local_host_blacklist;"}}
+  condition = ${lookup{$local_part@$domain}lsearch{CONFDIR/spamtrap_receiver} {yes}{no}}
+  logwrite = :main,reject: $sender_host_address - IP logged, $local_part@$domain is only used by spammers
+
+# drop backscatterer messages
+deny
+  senders = : $local_part@$domain
+  dnslists  = ips.backscatterer.org
+  add_header = X-blacklisted-at: $dnslist_domain
+  log_message = sender same as recipient $local_part@$domain and $sender_host_address listed at $dnslist_domain
+
+
 # Use spfquery to perform a pair of SPF checks (for details, see
 # http://www.openspf.org/)
 # This check has been copied from a stock Debian config and has not been


### PR DESCRIPTION
spamtrap/honeypot:
define a list of email addresses which you lay out as a bait on websites "CONFDIR/spamtrap_receiver"
one address per line
IPs of senders to these addresses will be logged to "/etc/exim4/local_host_blacklist"
and be rejected in the future
just put the bait email addresses in a hidden/invisible area on your website
i gathered ~500 IPs in one month

backscatterer:
as i see lots of mails coming from somwhere but the sender pretends to be my domain i created this acl
mails from "abc123@example.com" to "xyz987@example.com" will be ckecked against the backscatterer DNSBL
