### PR TITLE
TLS cipher settings

### DIFF
--- a/docs/configure
+++ b/docs/configure
@@ -288,9 +288,8 @@ tls_certificate = /etc/exim4/exim.crt
 tls_privatekey = /etc/exim4/exim.key
 tls_dhparam = /etc/exim4/dhparam.pem
 tls_require_ciphers = ${if =={$received_port}{25}\
-{NORMAL:%COMPAT:!VERS-SSL3.0}\
-{SECURE128}}
-
+    {NORMAL:%COMPAT:-ARCFOUR-128:-ARCFOUR-40:-MD5:-VERS-SSL3.0}\
+    {SECURE128:+AES-256-CBC:+CAMELLIA-256-CBC:-ARCFOUR-128:-ARCFOUR-40:-MD5:-VERS-SSL3.0}}
 
 ######################################################################
 #                       ACL CONFIGURATION                            #


### PR DESCRIPTION
Just applying the suggestion of @SvenBunge: https://github.com/vexim/vexim2/pull/45#issuecomment-130092012
It worked for me on Debian 7/8 and Ubuntu 14.04.