### PR TITLE
Updated MySQL setup script

### DIFF
--- a/setup/mysql.sql
+++ b/setup/mysql.sql
@@ -1,160 +1,222 @@
+--
 -- Password for siteadmin is CHANGE. SHA512 is used by default, other
 -- crypting schemes can be found at the end of this file
 --
--- Database: `vexim`
---
-CREATE DATABASE IF NOT EXISTS `vexim` DEFAULT CHARACTER SET utf8;
+
+SET @OLD_CHARACTER_SET_CLIENT=@@CHARACTER_SET_CLIENT;
+SET @OLD_CHARACTER_SET_RESULTS=@@CHARACTER_SET_RESULTS;
+SET @OLD_COLLATION_CONNECTION=@@COLLATION_CONNECTION;
+SET NAMES utf8;
+SET @OLD_TIME_ZONE=@@TIME_ZONE;
+SET TIME_ZONE='+00:00';
+SET @OLD_UNIQUE_CHECKS=@@UNIQUE_CHECKS, UNIQUE_CHECKS=0;
+SET @OLD_FOREIGN_KEY_CHECKS=@@FOREIGN_KEY_CHECKS, FOREIGN_KEY_CHECKS=0;
+SET @OLD_SQL_MODE=@@SQL_MODE, SQL_MODE='NO_AUTO_VALUE_ON_ZERO';
+SET @OLD_SQL_NOTES=@@SQL_NOTES, SQL_NOTES=0;
 
 --
--- Table: `domains`
+-- Uncomment the following block if you want this script to create 
+-- the database for you and set up its access.
+-- Don't forget to change the password.
+-- You may also change the database and user names if you want.
 --
-DROP TABLE IF EXISTS `vexim`.`domains`;
-CREATE TABLE IF NOT EXISTS `vexim`.`domains`
-(
-    domain_id      mediumint(8)  unsigned  NOT NULL  auto_increment,
-	domain           varchar(255)            NOT NULL  default '',
-	maildir          varchar(4096)           NOT NULL  default '',
-	uid              smallint(5)   unsigned  NOT NULL  default 'CHANGE',
-	gid              smallint(5)   unsigned  NOT NULL  default 'CHANGE',
-	max_accounts     int(10)       unsigned  NOT NULL  default '0', 
-	quotas           int(10)       unsigned  NOT NULL  default '0',
-	type             varchar(5)                        default NULL,
-	avscan           bool                    NOT NULL  default '0',
-	blocklists       bool                    NOT NULL  default '0',
-	enabled          bool                    NOT NULL  default '1',
-	mailinglists     bool                    NOT NULL  default '0',
-	maxmsgsize       mediumint(8)  unsigned  NOT NULL  default '0',
-	pipe             bool                    NOT NULL  default '0',
-	spamassassin     bool                    NOT NULL  default '0',
-	sa_tag           smallint(5)   unsigned  NOT NULL  default '0',
-	sa_refuse        smallint(5)   unsigned  NOT NULL  default '0',
-	PRIMARY KEY (domain_id),
-	UNIQUE KEY domain (domain)
-);
+
+-- CREATE DATABASE IF NOT EXISTS `vexim` DEFAULT CHARACTER SET utf8;
+-- USE `vexim`;
+-- GRANT SELECT,INSERT,DELETE,UPDATE ON `vexim`.* to "vexim"@"localhost" 
+--    IDENTIFIED BY 'CHANGE';
+-- FLUSH PRIVILEGES;
 
 --
--- Table: `users`
+-- Table structure for table `domains`
 --
-DROP TABLE IF EXISTS `vexim`.`users`;
-CREATE TABLE IF NOT EXISTS `vexim`.`users` 
-(
-    user_id          int(10)       unsigned  NOT NULL  auto_increment,
-	domain_id        mediumint(8)  unsigned  NOT NULL,
-	localpart        varchar(64)             NOT NULL  default '',
-	username         varchar(255)            NOT NULL  default '',
-	crypt            varchar(255)                       default NULL,
-	uid              smallint(5)   unsigned  NOT NULL  default '65534',
-	gid              smallint(5)   unsigned  NOT NULL  default '65534',
-	smtp             varchar(4096)                     default NULL,
-	pop              varchar(4096)                     default NULL,
-	type             enum('local', 'alias', 
-                          'catch', 'fail', 
-                          'piped', 'admin', 
-                          'site')            NOT NULL  default 'local',
-	admin            bool                    NOT NULL  default '0',
-	on_avscan        bool                    NOT NULL  default '0',
-	on_blocklist     bool                    NOT NULL  default '0',
-	on_forward       bool                    NOT NULL  default '0',
-	on_piped         bool                    NOT NULL  default '0',
-	on_spamassassin  bool                    NOT NULL  default '0',
-	on_vacation      bool                    NOT NULL  default '0',
-	spam_drop        bool                    NOT NULL  default '0',
-	enabled          bool                    NOT NULL  default '1',
-	flags            varchar(16)                       default NULL,
-	forward          varchar(255)                      default NULL,
-    unseen           bool                              default '0',
-	maxmsgsize       mediumint(8)  unsigned  NOT NULL  default '0',
-	quota            int(10)       unsigned  NOT NULL  default '0',
-	realname         varchar(255)                      default NULL,
-	sa_tag           smallint(5)   unsigned  NOT NULL  default '0',
-	sa_refuse        smallint(5)   unsigned  NOT NULL  default '0',
-	tagline          varchar(255)                      default NULL,
-	vacation         varchar(1024)                      default NULL,
-	PRIMARY KEY (user_id),
-	UNIQUE KEY username (localpart, domain_id),
-	KEY local (localpart)
-);
+
+DROP TABLE IF EXISTS `domains`;
+CREATE TABLE `domains` (
+  `domain_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `domain` varchar(255) NOT NULL DEFAULT '',
+  `maildir` varchar(4096) NOT NULL DEFAULT '',
+  `uid` smallint(5) unsigned NOT NULL DEFAULT '65534',
+  `gid` smallint(5) unsigned NOT NULL DEFAULT '65534',
+  `max_accounts` int(10) unsigned NOT NULL DEFAULT '0',
+  `quotas` int(10) unsigned NOT NULL DEFAULT '0',
+  `type` varchar(5) DEFAULT NULL,
+  `avscan` tinyint(1) NOT NULL DEFAULT '0',
+  `blocklists` tinyint(1) NOT NULL DEFAULT '0',
+  `enabled` tinyint(1) NOT NULL DEFAULT '1',
+  `mailinglists` tinyint(1) NOT NULL DEFAULT '0',
+  `maxmsgsize` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `pipe` tinyint(1) NOT NULL DEFAULT '0',
+  `spamassassin` tinyint(1) NOT NULL DEFAULT '0',
+  `sa_tag` smallint(5) unsigned NOT NULL DEFAULT '0',
+  `sa_refuse` smallint(5) unsigned NOT NULL DEFAULT '0',
+  PRIMARY KEY (`domain_id`),
+  UNIQUE KEY `domain` (`domain`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 --
--- Table: `blocklists`
+-- Table structure for table `users`
 --
-DROP TABLE IF EXISTS `vexim`.`blocklists`;
-CREATE TABLE IF NOT EXISTS `vexim`.`blocklists`
-(
-    block_id         int(10)       unsigned  NOT NULL  auto_increment,
-  	domain_id        mediumint(8)  unsigned  NOT NULL,
-	user_id          int(10)       unsigned            default NULL,
-	blockhdr         varchar(192)            NOT NULL  default '',
-	blockval         varchar(255)            NOT NULL  default '',
-	color            varchar(8)              NOT NULL  default '',
-	PRIMARY KEY (block_id)
-);
 
-
---
--- Table: `domainalias`
---
-CREATE TABLE IF NOT EXISTS `vexim`.`domainalias` 
-(
-	domain_id        mediumint(8)  unsigned  NOT NULL,
-	alias            varchar(255)            NOT NULL,
-	PRIMARY KEY (alias)
-);
-
---
--- Table: `groups`
---
-DROP TABLE IF EXISTS `vexim`.`groups`;
-CREATE TABLE IF NOT EXISTS `vexim`.`groups`
-(
-    id               int(10)                           auto_increment,
-    domain_id        mediumint(8)  unsigned  NOT NULL,
-    name             varchar(64)             NOT NULL,
-    is_public        char(1)                 NOT NULL  default 'Y',
-    enabled          bool                    NOT NULL  default '1',
-    PRIMARY KEY (id),
-    UNIQUE KEY group_name(domain_id, name)
-);
-
---
--- Table: `group_contents`
---
-DROP TABLE IF EXISTS `vexim`.`group_contents`;
-CREATE TABLE IF NOT EXISTS `vexim`.`group_contents` 
-(
-    group_id         int(10)                 NOT NULL,
-    member_id        int(10)                 NOT NULL,
-    PRIMARY KEY (group_id, member_id)
-);
+DROP TABLE IF EXISTS `users`;
+CREATE TABLE `users` (
+  `user_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `domain_id` int(10) unsigned NOT NULL,
+  `localpart` varchar(64) NOT NULL DEFAULT '',
+  `username` varchar(255) NOT NULL DEFAULT '',
+  `crypt` varchar(255) DEFAULT NULL,
+  `uid` smallint(5) unsigned NOT NULL DEFAULT '65534',
+  `gid` smallint(5) unsigned NOT NULL DEFAULT '65534',
+  `smtp` varchar(4096) DEFAULT NULL,
+  `pop` varchar(4096) DEFAULT NULL,
+  `type` enum('local','alias','catch','fail','piped','admin','site') NOT NULL DEFAULT 'local',
+  `admin` tinyint(1) NOT NULL DEFAULT '0',
+  `on_avscan` tinyint(1) NOT NULL DEFAULT '0',
+  `on_blocklist` tinyint(1) NOT NULL DEFAULT '0',
+  `on_forward` tinyint(1) NOT NULL DEFAULT '0',
+  `on_piped` tinyint(1) NOT NULL DEFAULT '0',
+  `on_spamassassin` tinyint(1) NOT NULL DEFAULT '0',
+  `on_vacation` tinyint(1) NOT NULL DEFAULT '0',
+  `spam_drop` tinyint(1) NOT NULL DEFAULT '0',
+  `enabled` tinyint(1) NOT NULL DEFAULT '1',
+  `flags` varchar(16) DEFAULT NULL,
+  `forward` varchar(255) DEFAULT NULL,
+  `unseen` tinyint(1) DEFAULT '0',
+  `maxmsgsize` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `quota` int(10) unsigned NOT NULL DEFAULT '0',
+  `realname` varchar(255) DEFAULT NULL,
+  `sa_tag` smallint(5) unsigned NOT NULL DEFAULT '0',
+  `sa_refuse` smallint(5) unsigned NOT NULL DEFAULT '0',
+  `tagline` varchar(255) DEFAULT NULL,
+  `vacation` varchar(1024) DEFAULT NULL,
+  PRIMARY KEY (`user_id`),
+  UNIQUE INDEX `username` (`localpart`, `domain_id`),
+  INDEX `local` (`localpart`),
+  INDEX `fk_users_domain_id_idx` (`domain_id`),
+  CONSTRAINT `fk_users_domain_id`
+    FOREIGN KEY (`domain_id`)
+    REFERENCES `domains` (`domain_id`)
+    ON DELETE CASCADE
+    ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 --
--- Privileges:
+-- Table structure for table `blocklists`
 --
-GRANT SELECT,INSERT,DELETE,UPDATE ON `vexim`.* to "vexim"@"localhost" 
-    IDENTIFIED BY 'CHANGE';
-FLUSH PRIVILEGES;
+
+DROP TABLE IF EXISTS `blocklists`;
+CREATE TABLE `blocklists` (
+  `block_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `domain_id` int(10) unsigned NOT NULL,
+  `user_id` int(10) unsigned DEFAULT NULL,
+  `blockhdr` varchar(192) NOT NULL DEFAULT '',
+  `blockval` varchar(255) NOT NULL DEFAULT '',
+  `color` varchar(8) NOT NULL DEFAULT '',
+  PRIMARY KEY (`block_id`),
+  INDEX `fk_blocklists_domain_id_idx` (`domain_id`),
+  INDEX `fk_blocklists_user_id_idx` (`user_id`),
+  CONSTRAINT `fk_blocklists_domain_id`
+    FOREIGN KEY (`domain_id`)
+    REFERENCES `domains` (`domain_id`)
+    ON DELETE CASCADE
+    ON UPDATE CASCADE,
+  CONSTRAINT `fk_blocklists_user_id`
+    FOREIGN KEY (`user_id`)
+    REFERENCES `users` (`user_id`)
+    ON DELETE CASCADE
+    ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 --
--- add initial domain: admin
+-- Table structure for table `domainalias`
 --
-INSERT INTO `vexim`.`domains` (domain_id, domain) VALUES ('1', 'admin');
+
+DROP TABLE IF EXISTS `domainalias`;
+CREATE TABLE `domainalias` (
+  `domain_id` int(10) unsigned NOT NULL,
+  `alias` varchar(255) NOT NULL,
+  PRIMARY KEY (`alias`),
+  INDEX `fk_domainalias_domain_id_idx` (`domain_id`),
+  CONSTRAINT `fk_domainalias_domain_id`
+    FOREIGN KEY (`domain_id`)
+    REFERENCES `domains` (`domain_id`)
+    ON DELETE CASCADE
+    ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 --
--- add initial user; postmaster
+-- Table structure for table `groups`
 --
-INSERT INTO `vexim`.`users`
-(
-    domain_id, localpart, username, crypt, uid, gid, 
-    smtp, pop, realname, type, admin
-)
-VALUES 
-(   '1', 'siteadmin', 'siteadmin', '$6$uR.EiB1dj5rrvwMF$Qh5LgdjOZavKXwhi9IF0Yuzu7qxsG.dLTTB8e./55ZRNfBuZVLnfUSOEXa0oWT6174myO.WYkOy83HYWAKPbK/', '65535', '65535', '', '',  'SiteAdmin', 'site', '1'
-);
 
--- fix password when using bcrypt (on *BSD only) encrypted password:
+DROP TABLE IF EXISTS `groups`;
+CREATE TABLE `groups` (
+  `id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `domain_id` int(10) unsigned NOT NULL,
+  `name` varchar(64) NOT NULL,
+  `is_public` char(1) NOT NULL DEFAULT 'Y',
+  `enabled` tinyint(1) NOT NULL DEFAULT '1',
+  PRIMARY KEY (`id`),
+  UNIQUE INDEX `group_name` (`domain_id`, `name`),
+  CONSTRAINT `fk_groups_domain_id`
+    FOREIGN KEY (`domain_id`)
+    REFERENCES `domains` (`domain_id`)
+    ON DELETE CASCADE
+    ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+--
+-- Table structure for table `group_contents`
+--
+
+DROP TABLE IF EXISTS `group_contents`;
+CREATE TABLE `group_contents` (
+  `group_id` int(10) unsigned NOT NULL,
+  `member_id` int(10) unsigned NOT NULL,
+  PRIMARY KEY (`group_id`, `member_id`),
+  INDEX `fk_group_contents_member_id_idx` (`member_id` ASC),
+  CONSTRAINT `fk_group_contents_group_id`
+    FOREIGN KEY (`group_id`)
+    REFERENCES `groups` (`id`)
+    ON DELETE CASCADE
+    ON UPDATE CASCADE,
+  CONSTRAINT `fk_group_contents_member_id`
+    FOREIGN KEY (`member_id`)
+    REFERENCES `users` (`user_id`)
+    ON DELETE CASCADE
+    ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+--
+-- Dumping data for table `domains`
+--
+
+LOCK TABLES `domains` WRITE;
+ALTER TABLE `domains` DISABLE KEYS;
+INSERT INTO `domains` VALUES (1,'admin','',65534,65534,0,0,NULL,0,0,1,0,0,0,0,0,0);
+ALTER TABLE `domains` ENABLE KEYS;
+UNLOCK TABLES;
+
+--
+-- Dumping data for table `users`
+--
+
+LOCK TABLES `users` WRITE;
+ALTER TABLE `users` DISABLE KEYS;
+INSERT INTO `users` VALUES (1,1,'siteadmin','siteadmin','$6$uR.EiB1dj5rrvwMF$Qh5LgdjOZavKXwhi9IF0Yuzu7qxsG.dLTTB8e./55ZRNfBuZVLnfUSOEXa0oWT6174myO.WYkOy83HYWAKPbK/',65535,65535,'','','site',1,0,0,0,0,0,0,0,1,NULL,NULL,0,0,0,'SiteAdmin',0,0,NULL,NULL);
+
+-- fix password if using bcrypt (on *BSD only) encrypted passwords:
 -- UPDATE `vexim`.`users` SET `crypt` = '$2a$10$KKtb78YkexNl4Ik3RymPEObqTsk/ivneEHl/Q5TsDpRBGyYjOl33G'
 --   WHERE `user_id` = '1' LIMIT 1 ;
 
--- fix password when using clear password:
--- UPDATE `vexim`.`users` SET `crypt` = 'CHANGE'
---   WHERE `user_id` = '1' LIMIT 1 ;
+ALTER TABLE `users` ENABLE KEYS;
+UNLOCK TABLES;
+
+
+SET TIME_ZONE=@OLD_TIME_ZONE;
+SET SQL_MODE=@OLD_SQL_MODE;
+SET FOREIGN_KEY_CHECKS=@OLD_FOREIGN_KEY_CHECKS;
+SET UNIQUE_CHECKS=@OLD_UNIQUE_CHECKS;
+SET CHARACTER_SET_CLIENT=@OLD_CHARACTER_SET_CLIENT;
+SET CHARACTER_SET_RESULTS=@OLD_CHARACTER_SET_RESULTS;
+SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION;
+SET SQL_NOTES=@OLD_SQL_NOTES;


### PR DESCRIPTION
- All id columns have been changed to int(10) unsigned not null
- Foreign keys have been added to all tables referencing other tables
- Default `uid` and `gid` values in `domains` table have been changed to `65534`. This alleviates the need to edit this file manually before applying it. From looking at the code, it seems to me that `uid` and `gid` are always passed when creating a domain, so this requirement to edit the SQL default value is most likely unnecessary.

The SQL file itself was created using `mysqldump` and edited manually afterwards, that's why most of the file differs: `mysqldump` adds backticks around fields and indents them differently from what we had.

All FK's are currently ON UPDATE CASCADE ON DELETE CASCADE. This might need some tuning, although I'm not exactly sure.

@Udera: would you mind checking this out? I thought it might be nice to introduce these changes before finalizing the upgrade script to 2.3 in #72. On the other hand, these foreign key aren't that necessary and if we decide not to go that way in 2.3, I could make a much smaller alternative patch for point 3 only.