### PR TITLE
Remove user/group assignment and transports for alias-forwards.

### DIFF
--- a/docs/configure
+++ b/docs/configure
@@ -833,10 +833,6 @@ system_aliases:
   allow_fail
   allow_defer
   data = ${lookup{$local_part}lsearch{/etc/aliases}}
-  user = mailnull
-  group = mail
-  file_transport = address_file
-  pipe_transport = address_pipe
 
 
 # This router handles forwarding using traditional .forward files in users'


### PR DESCRIPTION
Tested on debian 8 👍 
Follow up on changes in https://github.com/vexim/vexim2/pull/170