### PR TITLE
Run spamassassin with vmail user

### DIFF
--- a/docs/configure
+++ b/docs/configure
@@ -192,6 +192,13 @@ av_scanner = clamd:/var/run/clamav/clamd
 
 spamd_address = 127.0.0.1 783
 
+# User who passes mails to spamassassin. He should have a home directory in order
+# to save configuration and scanning data (e.g. for Bayes filter). The default 
+# vexim-user can be used for this purpose. If the user does not exist, SpamAssassin 
+# will fall back to "nobody" and default settings, with all consequences.
+
+VEXIM_SA_USERNAME = vexim
+
 # Specify the domain you want to be added to all unqualified addresses
 # here. An unqualified address is one that does not contain an "@" character
 # followed by a domain. For example, "caesar@rome.example" is a fully qualified

--- a/docs/vexim-acl-check-content.conf
+++ b/docs/vexim-acl-check-content.conf
@@ -24,10 +24,8 @@
 
   # Pass missing spam score and report data to routers and transports, but do not reject anything yet.
   # Also, if set, remove X-Spam-* headers here: we will add our own ones later.
-  # NOTE: If the "maildeliver" user does not exist, SpamAssassin will fall back to "nobody" and default
-  # settings, with all consequences. You may want to change this user name and/or create a user.
   #
-  warn  spam                     = maildeliver:true
+  warn  spam                     = VEXIM_SA_USERNAME:true
         set acl_m_spam_score     = $spam_score
         set acl_m_spam_bar       = $spam_bar
         set acl_m_spam_report    = $spam_report


### PR DESCRIPTION
I always run my spamassassin with the `vexim` user. This way all the .spamassassin training files, special configuration, ... is within the home-folder of the `vexim`-user.

Does it make sense to take the exim-user?
