### PR TITLE
Replace `imap_qprint()` and `imap_8bit()` with `quoted_printable_[de|en]code()`

### DIFF
--- a/vexim/adminuserchange.php
+++ b/vexim/adminuserchange.php
@@ -268,17 +268,10 @@
           </td>
         </tr>
         <tr>
-        <?php if (function_exists('imap_qprint')) { ?>
           <td><?php echo _('Vacation message'); ?>:</td>
           <td>
-            <textarea name="vacation" cols="40" rows="5" class="textfield"><?php print imap_qprint($row['vacation']); ?></textarea>
+            <textarea name="vacation" cols="40" rows="5" class="textfield"><?php print quoted_printable_decode($row['vacation']); ?></textarea>
           </td>
-        <?php } else { ?>
-          <td><?php echo _('Vacation message (ASCII only!)'); ?>:</td>
-          <td>
-            <textarea name="vacation" cols="40" rows="5" class="textfield"><?php print $row['vacation']; ?></textarea>
-          </td>
-        <?php } ?>
         </tr>
         <tr>
           <td><?php echo _('Forwarding on'); ?>:</td>

--- a/vexim/adminuserchangesubmit.php
+++ b/vexim/adminuserchangesubmit.php
@@ -165,9 +165,7 @@
 
   if (isset($_POST['vacation']) && is_string($_POST['vacation'])) {
     $vacation = trim($_POST['vacation']);
-    if (function_exists('imap_8bit')) {
-      $vacation = imap_8bit($vacation);
-    }
+    $vacation = quoted_printable_encode($vacation);
   } else {
     $vacation = '';
   }

--- a/vexim/config/functions.php
+++ b/vexim/config/functions.php
@@ -199,17 +199,12 @@
         if (function_exists('mb_encode_mimeheader')) {
             mb_internal_encoding('UTF-8');
             $text = mb_encode_mimeheader($text, 'UTF-8', 'Q');
-        } elseif (function_exists('imap_8bit')) {
-            $text = str_replace(" ", "_", imap_8bit(trim($text)));
+        } else {
+            $text = str_replace(" ", "_", quoted_printable_encode(trim($text)));
             $text = str_replace("?", "=3F", $text);
             $text = str_replace("=\r\n", "?=\r\n =?UTF-8?Q?", $text);
             $text = "=?UTF-8?Q?" . $text . "?=" ;
         }
-        // if both mb and imap are not available, simply return what was given.
-        // this isn't standards-compliant, and the header will be displayed
-        // incorrectly if it contains accented letters. Let's just hope it won't
-        // be the case too often. :)
-        return $text;
     }
 
     /**

--- a/vexim/userchange.php
+++ b/vexim/userchange.php
@@ -125,17 +125,8 @@
 	    </td>
   	  </tr>
   	  <tr>
-        <?php if (function_exists('imap_qprint')) { ?>
   	    <td><?php echo _('Vacation message'); ?>:</td>
-  	    <td>
-            <textarea name="vacation" cols="40" rows="5" class="textfield"><?php print imap_qprint($row['vacation']); ?></textarea>
-          </td>
-        <?php } else { ?>
-  	    <td><?php echo _('Vacation message (ASCII only!)'); ?>:</td>
-  	    <td>
-            <textarea name="vacation" cols="40" rows="5" class="textfield"><?php print $row['vacation']; ?></textarea>
-	    </td>
-        <?php } ?>
+  	    <td><textarea name="vacation" cols="40" rows="5" class="textfield"><?php print quoted_printable_decode($row['vacation']); ?></textarea></td>
   	  </tr>
   	  <tr><td><?php echo _("Forwarding enabled"); ?>:</td>
   	    <td><input name="on_forward" type="checkbox" id="on_forward"

--- a/vexim/userchangesubmit.php
+++ b/vexim/userchangesubmit.php
@@ -81,9 +81,7 @@
 
   if (isset($_POST['vacation']) && is_string($_POST['vacation'])) {
     $vacation = trim($_POST['vacation']);
-    if (function_exists('imap_8bit')) {
-      $vacation = imap_8bit($vacation);
-    }
+    $vacation = quoted_printable_encode($vacation);
   } else {
     $vacation = '';
   }


### PR DESCRIPTION
Instead of using these functions provided by the IMAP module, which might be unavailable, we can use `quoted_printable_encode()` and `quoted_printable_decode()`. This means that we'll only depend on the IMAP module to check user's quota from now on.