### PR TITLE
Do not add spam headers during ACL phase so we don't have to remove them later

### DIFF
--- a/docs/configure
+++ b/docs/configure
@@ -87,9 +87,13 @@ hostlist   relay_from_hosts = localhost : @ : 192.168.0.0/24
 # Comment this line if you want to disable it, instead of + you can use a different separator.
 VEXIM_LOCALPART_SUFFIX = +*
 
-# if you exim version < 4.83 , define macro below for enabling new
-# 'headers_remove' behavior. See https://github.com/vexim/vexim2/pull/102 .
-#OLD_HEADERS_REMOVE = yes
+# Exim will put the detailed spam report into an X-Spam-Report header by default.
+# This report is really huge by default, but its template can be tweaked to make
+# it look almost exactly like contents of the X-Spam-Status header, which
+# SpamAssassin adds when scanning messages externally, and which is a much more
+# compact version of the report. If you tweak your template this way, you may
+# as well want to change the header name here.
+#VEXIM_SPAM_REPORT_HEADER_NAME = X-Spam-Status
 
 # Reverse DNS checks can be efficient to fight spam. It checks if host name associated to the ip address matches
 # the sender_host_name (for properly configured mail servers this should be the case). However, there are some
@@ -463,6 +467,11 @@ acl_check_content:
 
 begin routers
 
+# Make sure that the name of the spam report header is set.
+.ifndef VEXIM_SPAM_REPORT_HEADER_NAME
+VEXIM_SPAM_REPORT_HEADER_NAME = X-Spam-Report
+.endif
+
 # This router routes to remote hosts over SMTP by explicit IP address,
 # when an email address is given in "domain literal" form, for example,
 # <user@[192.168.35.64]>. The RFCs require this facility. However, it is
@@ -476,7 +485,6 @@ begin routers
 #   driver = ipliteral
 #   domains = ! +local_domains
 #   transport = remote_smtp
-#   headers_remove = X-Spam-Report:X-Spam-Score
 
 
 # This router routes addresses that are not in local domains by doing a DNS
@@ -492,7 +500,6 @@ dnslookup:
   domains = ! +local_domains
   transport = remote_smtp
   ignore_target_hosts = 0.0.0.0 : 127.0.0.0/8
-  headers_remove = X-Spam-Report:X-Spam-Score
   no_more
 
 mailman_router:
@@ -502,7 +509,6 @@ mailman_router:
   local_part_suffix = -bounces : -bounces+* : \
                       -confirm+* : -join : -leave : \
                       -owner : -request : -admin
-  headers_remove = X-Spam-Score:X-Spam-Report
   transport = mailman_transport
 
 # The remaining routers handle addresses in the local domain(s).
@@ -597,6 +603,10 @@ ditch_spam:
         and users.domain_id=domains.domain_id \ 
         and users.sa_refuse > 0 }{$value}fail}} {yes}{no}}
     retry_use_local_part
+    headers_add = ${if and { \
+                     {match{$domain}{$original_domain}} \
+                     {match{$local_part}{$original_local_part}} \
+                     } {X-Spam-Flag: YES\nX-Spam-Score: $acl_m_spam_score\nVEXIM_SPAM_REPORT_HEADER_NAME: $acl_m_spam_report}{} }
 
 ditch_hdrmailer:
   driver = redirect
@@ -715,31 +725,11 @@ virtual_domains:
   allow_fail
   data = ${extract{smtp}{$address_data}}
   headers_add = ${if and { \
+                    {match{$domain}{$original_domain}} \
+                    {match{$local_part}{$original_local_part}} \
                     {>{$spam_score_int}{${extract{sa_tag}{$address_data}}}} \
                     {eq{1}{${extract{on_spamassassin}{$address_data}}}} \
-                    } {X-Spam-Flag: YES\n}{} }
-  # Whether to use old or new headers_remove behavior.
-  .ifndef OLD_HEADERS_REMOVE
-    headers_remove = ${if or { { <{$spam_score_int}{1} } \
-                              { and {{<{$spam_score_int}{${extract{sa_tag}{$address_data}}} } \
-                                     {eq {1}{${extract{on_spamassassin}{$address_data}}}} \
-                                    } \
-                              } { eq {0}{${extract{on_spamassassin}{$address_data}}}} \
-                            }  {X-Spam-Score}}
-    headers_remove = ${if or { { <{$spam_score_int}{1} } \
-                              { and {{<{$spam_score_int}{${extract{sa_tag}{$address_data}}} } \
-                                     {eq {1}{${extract{on_spamassassin}{$address_data}}}} \
-                                    } \
-                              } { eq {0}{${extract{on_spamassassin}{$address_data}}}} \
-                            }  {X-Spam-Report}}
-  .else
-    headers_remove = ${if or { { <{$spam_score_int}{1} } \
-                              { and {{<{$spam_score_int}{${extract{sa_tag}{$address_data}}} } \
-                                     {eq {1}{${extract{on_spamassassin}{$address_data}}}} \
-                                    } \
-                              } { eq {0}{${extract{on_spamassassin}{$address_data}}}} \
-                            }  {X-Spam-Score:X-Spam-Report}}
-  .endif
+                    } {X-Spam-Flag: YES\nX-Spam-Score: $acl_m_spam_score\nVEXIM_SPAM_REPORT_HEADER_NAME: $acl_m_spam_report}{} }
   # using local_part_suffixes enables possibility to use user-"something" localparts
   # which could cause you trouble if you're creating email-adresses with dashes in between.
   .ifdef VEXIM_LOCALPART_SUFFIX

--- a/docs/configure
+++ b/docs/configure
@@ -455,7 +455,7 @@ acl_check_content:
 
   # finally accept all the rest
   accept
-  
+
 
 ######################################################################
 #                      ROUTERS CONFIGURATION                         #
@@ -560,7 +560,7 @@ ditch_malware:
   condition = ${if and { {match {$h_X-ACL-Warn:}{.*malware.*}} \
                          {eq {${lookup mysql{select users.on_avscan from users,domains \
 		                where localpart = '${quote_mysql:$local_part}' \
-		                and domain = '${quote_mysql:$domain}' \ 
+		                and domain = '${quote_mysql:$domain}' \
 		                and users.on_avscan = '1' \
                                 and domains.avscan = '1' \
 		                and users.domain_id=domains.domain_id}}}{1} }} {yes}{no} }
@@ -584,23 +584,23 @@ ditch_spam:
     driver = redirect
     allow_fail
     file_transport = virtual_ditch_spam_transport
-    data = ${lookup mysql{select concat(smtp,'/.Spam') \ 
-        from users,domains \ 
-        where localpart = '${quote_mysql:$local_part}' \ 
-        and domain = '${quote_mysql:$domain}' \ 
-        and domains.enabled = '1' \ 
-        and users.enabled = '1' \ 
+    data = ${lookup mysql{select concat(smtp,'/.Spam') \
+        from users,domains \
+        where localpart = '${quote_mysql:$local_part}' \
+        and domain = '${quote_mysql:$domain}' \
+        and domains.enabled = '1' \
+        and users.enabled = '1' \
         and users.domain_id = domains.domain_id}}
-    condition = ${if >{$spam_score_int}{${lookup mysql{select \ 
-        users.sa_refuse * 10 from users,domains \ 
-        where localpart = '${quote_mysql:$local_part}' \ 
-        and domain = '${quote_mysql:$domain}' \ 
-        and users.on_spamassassin = '1' \ 
+    condition = ${if >{$spam_score_int}{${lookup mysql{select \
+        users.sa_refuse * 10 from users,domains \
+        where localpart = '${quote_mysql:$local_part}' \
+        and domain = '${quote_mysql:$domain}' \
+        and users.on_spamassassin = '1' \
         and domains.spamassassin = '1' \
         and users.spam_drop = '0' \
         and users.on_forward = '0' \
         and users.type = 'local' \
-        and users.domain_id=domains.domain_id \ 
+        and users.domain_id=domains.domain_id \
         and users.sa_refuse > 0 }{$value}fail}} {yes}{no}}
     retry_use_local_part
     headers_add = ${if and { \
@@ -681,7 +681,7 @@ virtual_vacation:
   condition = ${if and { {!match {$h_precedence:}{(?i)junk|bulk|list}} \
                          {eq {${lookup mysql{select users.on_vacation from users,domains \
 		                where localpart = '${quote_mysql:$local_part}' \
-		                and domain = '${quote_mysql:$domain}' \ 
+		                and domain = '${quote_mysql:$domain}' \
 		                and users.on_vacation = '1' \
 		                and users.domain_id=domains.domain_id}}}{1} }} {yes}{no} }
   no_verify
@@ -706,7 +706,7 @@ virtual_forward:
   condition = ${if and { {!match {$h_precedence:}{(?i)junk}} \
                          {eq {${lookup mysql{select users.on_forward from users,domains \
 		                where localpart = '${quote_mysql:$local_part}' \
-		                and domain = '${quote_mysql:$domain}' \ 
+		                and domain = '${quote_mysql:$domain}' \
 		                and users.on_forward = '1' \
 		                and users.domain_id=domains.domain_id}}}{1} }} {yes}{no} }
 
@@ -803,7 +803,7 @@ virtual_domain_alias:
   		from domains,domainalias where domainalias.alias = '${quote_mysql:$domain}' \
 		and domainalias.domain_id = domains.domain_id}}
   retry_use_local_part
-  
+
 
 # This router handles aliasing using a linearly searched alias file with the
 # name /etc/aliases. When this configuration is installed automatically,
@@ -953,13 +953,13 @@ virtual_ditch_spam_transport:
   mode = 0600
   maildir_format = true
   create_directory = true
-  user = ${lookup mysql{select users.uid  from users,domains \ 
-                where localpart = '${quote_mysql:$local_part}' \ 
-                and domain = '${quote_mysql:$domain}' \ 
+  user = ${lookup mysql{select users.uid  from users,domains \
+                where localpart = '${quote_mysql:$local_part}' \
+                and domain = '${quote_mysql:$domain}' \
                 and users.domain_id = domains.domain_id}}
-  group = ${lookup mysql{select users.gid from users,domains \ 
-                where localpart = '${quote_mysql:$local_part}' \ 
-                and domain = '${quote_mysql:$domain}' \ 
+  group = ${lookup mysql{select users.gid from users,domains \
+                where localpart = '${quote_mysql:$local_part}' \
+                and domain = '${quote_mysql:$domain}' \
                 and users.domain_id = domains.domain_id}}
   maildir_use_size_file = false
 

--- a/docs/debian-conf.d/main/00_vexim_listmacrosdefs
+++ b/docs/debian-conf.d/main/00_vexim_listmacrosdefs
@@ -2,10 +2,6 @@
 ### main/00_vexim_listmacrosdefs
 #################################
 
-# if you exim version < 4.83 , define macro below for enabling new
-# 'headers_remove' behavior. See https://github.com/vexim/vexim2/pull/102 .
-#OLD_HEADERS_REMOVE = yes
-
 hide mysql_servers = localhost::(/var/run/mysqld/mysqld.sock)/vexim/vexim/CHANGE
 
 # domains
@@ -51,3 +47,11 @@ VEXIM_LOCALPART_SUFFIX = +*
 
 CHECK_RCPT_LOCAL_ACL_FILE = /etc/exim4/vexim-acl-check-rcpt.conf
 CHECK_DATA_LOCAL_ACL_FILE = /etc/exim4/vexim-acl-check-content.conf
+
+# Exim will put the detailed spam report into an X-Spam-Report header by default.
+# This report is really huge by default, but its template can be tweaked to make
+# it look almost exactly like contents of the X-Spam-Status header, which
+# SpamAssassin adds when scanning messages externally, and which is a much more
+# compact version of the report. If you tweak your template this way, you may
+# as well want to change the header name here.
+VEXIM_SPAM_REPORT_HEADER_NAME = X-Spam-Report

--- a/docs/debian-conf.d/router/249_vexim_ditch_routers
+++ b/docs/debian-conf.d/router/249_vexim_ditch_routers
@@ -37,7 +37,7 @@ ditch_malware:
     condition = ${if and { {match {$h_X-ACL-Warn:}{.*malware.*}} \
         {eq {${lookup mysql{select users.on_avscan from users,domains \
         where localpart = '${quote_mysql:$local_part}' \
-        and domain = '${quote_mysql:$domain}' \ 
+        and domain = '${quote_mysql:$domain}' \
         and users.on_avscan = '1' \
         and domains.avscan = '1' \
         and users.domain_id=domains.domain_id}}}{1} }} {yes}{no} }
@@ -61,23 +61,23 @@ ditch_spam:
     driver = redirect
     allow_fail
     file_transport = virtual_ditch_spam_transport
-    data = ${lookup mysql{select concat(smtp,'/.Spam') \ 
-        from users,domains \ 
-        where localpart = '${quote_mysql:$local_part}' \ 
-        and domain = '${quote_mysql:$domain}' \ 
-        and domains.enabled = '1' \ 
-        and users.enabled = '1' \ 
+    data = ${lookup mysql{select concat(smtp,'/.Spam') \
+        from users,domains \
+        where localpart = '${quote_mysql:$local_part}' \
+        and domain = '${quote_mysql:$domain}' \
+        and domains.enabled = '1' \
+        and users.enabled = '1' \
         and users.domain_id = domains.domain_id}}
-    condition = ${if >{$spam_score_int}{${lookup mysql{select \ 
-        users.sa_refuse * 10 from users,domains \ 
-        where localpart = '${quote_mysql:$local_part}' \ 
-        and domain = '${quote_mysql:$domain}' \ 
-        and users.on_spamassassin = '1' \ 
+    condition = ${if >{$spam_score_int}{${lookup mysql{select \
+        users.sa_refuse * 10 from users,domains \
+        where localpart = '${quote_mysql:$local_part}' \
+        and domain = '${quote_mysql:$domain}' \
+        and users.on_spamassassin = '1' \
         and domains.spamassassin = '1' \
         and users.spam_drop = '0' \
         and users.on_forward = '0' \
         and users.type = 'local' \
-        and users.domain_id=domains.domain_id \ 
+        and users.domain_id=domains.domain_id \
         and users.sa_refuse > 0 }{$value}fail}} {yes}{no}}
     retry_use_local_part
     headers_add = ${if and { \

--- a/docs/debian-conf.d/router/249_vexim_ditch_routers
+++ b/docs/debian-conf.d/router/249_vexim_ditch_routers
@@ -80,6 +80,10 @@ ditch_spam:
         and users.domain_id=domains.domain_id \ 
         and users.sa_refuse > 0 }{$value}fail}} {yes}{no}}
     retry_use_local_part
+    headers_add = ${if and { \
+                     {match{$domain}{$original_domain}} \
+                     {match{$local_part}{$original_local_part}} \
+                     } {X-Spam-Flag: YES\nX-Spam-Score: $acl_m_spam_score\nVEXIM_SPAM_REPORT_HEADER_NAME: $acl_m_spam_report}{} }
 
 ditch_hdrmailer:
     driver = redirect

--- a/docs/debian-conf.d/router/250_vexim_virtual_domains
+++ b/docs/debian-conf.d/router/250_vexim_virtual_domains
@@ -53,31 +53,11 @@ virtual_domains:
   allow_fail
   data = ${extract{smtp}{$address_data}}
   headers_add = ${if and { \
+                    {match{$domain}{$original_domain}} \
+                    {match{$local_part}{$original_local_part}} \
                     {>{$spam_score_int}{${extract{sa_tag}{$address_data}}}} \
                     {eq{1}{${extract{on_spamassassin}{$address_data}}}} \
-                    } {X-Spam-Flag: YES\n}{} }
-  # Whether to use old or new headers_remove behavior.
-  .ifndef OLD_HEADERS_REMOVE
-    headers_remove = ${if or { { <{$spam_score_int}{1} } \
-                              { and {{<{$spam_score_int}{${extract{sa_tag}{$address_data}}} } \
-                                     {eq {1}{${extract{on_spamassassin}{$address_data}}}} \
-                                    } \
-                              } { eq {0}{${extract{on_spamassassin}{$address_data}}}} \
-                            }  {X-Spam-Score}}
-    headers_remove = ${if or { { <{$spam_score_int}{1} } \
-                              { and {{<{$spam_score_int}{${extract{sa_tag}{$address_data}}} } \
-                                     {eq {1}{${extract{on_spamassassin}{$address_data}}}} \
-                                    } \
-                              } { eq {0}{${extract{on_spamassassin}{$address_data}}}} \
-                            }  {X-Spam-Report}}
-  .else
-    headers_remove = ${if or { { <{$spam_score_int}{1} } \
-                              { and {{<{$spam_score_int}{${extract{sa_tag}{$address_data}}} } \
-                                     {eq {1}{${extract{on_spamassassin}{$address_data}}}} \
-                                    } \
-                              } { eq {0}{${extract{on_spamassassin}{$address_data}}}} \
-                            }  {X-Spam-Score:X-Spam-Report}}
-  .endif
+                    } {X-Spam-Flag: YES\nX-Spam-Score: $acl_m_spam_score\nVEXIM_SPAM_REPORT_HEADER_NAME: $acl_m_spam_report}{} }
   # using local_part_suffixes enables possibility to use user-"something" localparts
   # which could cause you trouble if you're creating email-adresses with dashes in between.
   .ifdef VEXIM_LOCALPART_SUFFIX

--- a/docs/vexim-acl-check-content.conf
+++ b/docs/vexim-acl-check-content.conf
@@ -27,6 +27,19 @@
   # Message scanning time grows exponentially in the size of the message and goes timeout
   # after 2~5 minutes, while typical spam has only a few KB in size.
   accept  condition = ${if >={$message_size}{300k}{yes}{no}}
+          remove_header = X-Spam-Flag : X-Spam-Score : X-Spam-Status : X-Spam-Report
+
+  # Pass missing spam score and report data to routers and transports, but do not reject anything yet.
+  # Also, if set, remove X-Spam-* headers here: we will add our own ones later.
+  # NOTE: If the "maildeliver" user does not exist, SpamAssassin will fall back to "nobody" and default
+  # settings, with all consequences. You may want to change this user name and/or create a user.
+  #
+  warn  spam                     = maildeliver:true
+        set acl_m_spam_score     = $spam_score
+        set acl_m_spam_bar       = $spam_bar
+        set acl_m_spam_report    = $spam_report
+        # $spam_score_int persists by itself
+        remove_header = X-Spam-Flag : X-Spam-Score : X-Spam-Status : X-Spam-Report
 
   # Reject mails with more than 15 spam-points. This is a system-wide setting and does not respect
   # individual user settings!

--- a/docs/vexim-acl-check-content.conf
+++ b/docs/vexim-acl-check-content.conf
@@ -1,31 +1,41 @@
   # First unpack MIME containers and reject serious errors.
-  deny  message		= This message contains a MIME error ($demime_reason)
-        demime		= *
-        condition	= ${if >{$demime_errorlevel}{2}{1}{0}}
-        
+  #
+  deny  message   = This message contains a MIME error ($demime_reason)
+        demime    = *
+        condition = ${if >{$demime_errorlevel}{2}{1}{0}}
+
   # Reject typically wormish file extensions. There is almost no
   # sense in sending such files by email.
   # Note that you might want to change the list of extensions.
+  #
   deny  message = This domain has a policy of not accepting certain types of attachments \
                   in mail as they may contain a virus.  This mail has a file with a .$found_extension \
                   attachment and is not accepted.  If you have a legitimate need to send \
                   this particular attachment, send it in a compressed archive, and it will \
                   then be forwarded to the recipient.
-        demime = ade:adep:adp:bas:bat:chm:cmd:cnf:com:cpl:crt:dll:hlp:hta:inf:ins:isp:js:jse:lnk:mad:maf:mag:mam:maq:mar:mas:mat:mav:maw:ocx:pcd:pif:reg:scf:scr:sct:vbe:vbs:wsc:wsf:wsh:url:xnk
+        demime  = ade:adep:adp:bas:bat:chm:cmd:cnf:com:cpl:crt:dll:hlp:hta:inf:ins:isp:js:jse:lnk:mad:maf:mag:mam:maq:mar:mas:mat:mav:maw:ocx:pcd:pif:reg:scf:scr:sct:vbe:vbs:wsc:wsf:wsh:url:xnk
 
   # Reject virus infested messages.
-  warn  message		= This message contains malware ($malware_name)
-        malware		= *
-        log_message	= This message contains malware ($malware_name)
+  #
+  warn    message     = This message contains malware ($malware_name)
+          malware     = *
+          log_message = This message contains malware ($malware_name)
+
+  # Reject messages with an "X-Spam-Flag: YES" header.
+  #
+  deny    message   = Sender openly considers message as spam (X-Spam-Flag header with a positive value was found).
+          condition = ${if bool{$h_x-spam-flag:}{true}{false}}
 
   # Reject messages containing "viagra" in all kinds of whitespace/case combinations
   # WARNING: this is an example !
-  # deny  message = This message matches a blacklisted regular expression ($regex_match_string)
-  #      regex = [Vv] *[Ii] *[Aa] *[Gg] *[Rr] *[Aa]
-  
+  #
+  # deny    message = This message matches a blacklisted regular expression ($regex_match_string)
+  #        regex   = [Vv] *[Ii] *[Aa] *[Gg] *[Rr] *[Aa]
+
   # Mails larger than 300 KB are accepted without spam-checking to save resources.
   # Message scanning time grows exponentially in the size of the message and goes timeout
   # after 2~5 minutes, while typical spam has only a few KB in size.
+  #
   accept  condition = ${if >={$message_size}{300k}{yes}{no}}
           remove_header = X-Spam-Flag : X-Spam-Score : X-Spam-Status : X-Spam-Report
 
@@ -41,17 +51,10 @@
         # $spam_score_int persists by itself
         remove_header = X-Spam-Flag : X-Spam-Score : X-Spam-Status : X-Spam-Report
 
-  # Reject mails with more than 15 spam-points. This is a system-wide setting and does not respect
-  # individual user settings!
-  #deny    message = This message has been rejected due to spam.
-  #        spam = maildeliver:true
-  #        condition = ${if >{$spam_score_int}{150}{true}{false}}
+  # Reject all mails with more than 15 spam points, REGARDLESS OF INDIVIDUAL USER SETTINGS.
+  #
+  # deny  message   = This message has been rejected due to spam.
+  #      condition = ${if >{$spam_score_int}{150}{true}{false}}
 
-  # Always add X-Spam-Score and X-Spam-Report headers, using SA system-wide settings
-  # (user "nobody"), no matter if over threshold or not.
-  warn  message		= X-Spam-Score: $spam_score ($spam_bar)
-        spam		= maildeliver:true
-  warn  message		= X-Spam-Report: $spam_report
-        spam		= maildeliver:true
   accept hosts		= 127.0.0.1:+relay_from_hosts
   accept authenticated	= *


### PR DESCRIPTION
Instead, persist `$spam_*` variables as `$acl_m_spam_*` (except `$spam_score_int`, which persists by itself), and use these variables to add headers at delivery time.
This will add `X-Spam-Score`, `X-Spam-Score-Int` and `X-Spam-Bar` headers regardless of whether or not the message is spam, but this can be easily changed.

Comments welcome.