### PR TITLE
No passwordcheck for relay-domains

### DIFF
--- a/vexim/siteaddsubmit.php
+++ b/vexim/siteaddsubmit.php
@@ -24,12 +24,6 @@
   } else {
     $_POST['pipe'] = 0;
   }
-  if ($_POST['type'] == "relay") {
-    $_POST['clear'] = $_POST['vclear'] = "BLANK";
-  }
-  if ($_POST['type'] == "alias") {
-    $_POST['clear'] = $_POST['vclear'] = "BLANK";
-  }
   if (!isset($_POST['max_accounts']) || $_POST['max_accounts'] == '') {
     $_POST['max_accounts'] = '0';
   }
@@ -79,12 +73,17 @@
     $pophomepath = $domainpath . "/" . $_POST['localpart'];
   }
 //Gah. Transactions!! -- GCBirzan
-  if ((validate_password($_POST['clear'], $_POST['vclear'])) &&
-    ($_POST['type'] != "alias")) {
-      if (!password_strengthcheck($_POST['clear'])) {  
-        header ("Location: site.php?weakpass={$_POST['domain']}");
-        die;
-      }
+  if ($_POST['type'] !== "alias") {
+    if ($_POST['type'] === "local") {
+        if (!validate_password($_POST['clear'], $_POST['vclear'])) {  
+          header ("Location: site.php?badpass={$_POST['domain']}");
+          die;
+        }
+        if (!password_strengthcheck($_POST['clear'])) {  
+          header ("Location: site.php?weakpass={$_POST['domain']}");
+          die;
+	}
+    }
     $query = "INSERT INTO domains 
               (domain, spamassassin, sa_tag, sa_refuse, avscan,
               max_accounts, quotas, maildir, pipe, enabled, uid, gid,

--- a/vexim/siteaddsubmit.php
+++ b/vexim/siteaddsubmit.php
@@ -83,13 +83,13 @@
       die;
     } else {
       header ("Location: site.php?added={$_POST['domain']}" .
-              "&amp;type={$_POST['type']}");
+              "&type={$_POST['type']}");
       die;
     }
   } else { // local or relay
       if ($_POST['type'] === "local") {
         if (!validate_password($_POST['clear'], $_POST['vclear'])) {  
-          header ("Location: site.php?badpass={$_POST['domain']}");
+          header ("Location: site.php?failaddedpassmismatch={$_POST['domain']}");
           die;
         }
         if (!password_strengthcheck($_POST['clear'])) {  
@@ -148,12 +148,8 @@
                 "&type={$_POST['type']}");
         die;
       }
-    } else {
-      header ("Location: site.php?failaddeddomerr={$_POST['domain']}");
-      die;
-    }
+    } 
+    header ("Location: site.php?failaddeddomerr={$_POST['domain']}");
   }
-  header ("Location: site.php?failaddedpassmismatch={$_POST['domain']}");
-
 ?>
 <!-- Layout and CSS tricks obtained from http://www.bluerobot.com/web/layouts/ -->


### PR DESCRIPTION
Fix for #211

`alias`-domains are inserted in a completely different table, therefore the split. Indeed we only need passwords for a new local domain, and there was a default password set. Now I changed it to verify passwords only for local domains.