### PR TITLE
Reject messages of accounts type='fail'

### DIFF
--- a/docs/configure
+++ b/docs/configure
@@ -387,6 +387,10 @@ acl_check_rcpt:
   # access (if tests below it fail).
 
   accept  domains       = +local_domains
+          condition     = ${if eq {1}{${lookup mysql{select count(*) from users,domains \
+                          where localpart = '${quote_mysql:$local_part}' \
+                          and domain = '${quote_mysql:$domain}' \
+                          and users.type = 'fail'}}} {no}{yes}}
           endpass
           verify        = recipient
 


### PR DESCRIPTION
Reject certain addresses of a domain (set by admin) directly during smtp session.

Now it also gets the unspecific message `relay not permitted`. Perhaps a separate rule would be better and then use a message like `Address has been disabled`.

This also lets me think of new options for the domain admin to disable an account. You could decide whether the address has been disabled or if you only disable it temporarily (spam attack whatever, and normal mailservers will try it again later).