### PR TITLE
Treat SA tag and refuse scores properly

### DIFF
--- a/docs/configure
+++ b/docs/configure
@@ -553,7 +553,7 @@ ditch_spam_drop:
     driver = redirect
     allow_fail
     data = :blackhole:
-    condition = ${if >{$spam_score_int}{${lookup mysql{select users.sa_refuse * 10 from users,domains \
+    condition = ${if >={$spam_score_int}{${lookup mysql{select users.sa_refuse * 10 from users,domains \
         where localpart = '${quote_mysql:$local_part}' \
         and domain = '${quote_mysql:$domain}' \
         and users.on_spamassassin = '1' \
@@ -574,7 +574,7 @@ ditch_spam:
         and domains.enabled = '1' \
         and users.enabled = '1' \
         and users.domain_id = domains.domain_id}}
-    condition = ${if >{$spam_score_int}{${lookup mysql{select \
+    condition = ${if >={$spam_score_int}{${lookup mysql{select \
         users.sa_refuse * 10 from users,domains \
         where localpart = '${quote_mysql:$local_part}' \
         and domain = '${quote_mysql:$domain}' \
@@ -710,7 +710,7 @@ virtual_domains:
   headers_add = ${if and { \
                     {match{$domain}{$original_domain}} \
                     {match{$local_part}{$original_local_part}} \
-                    {>{$spam_score_int}{${extract{sa_tag}{$address_data}}}} \
+                    {>={$spam_score_int}{${extract{sa_tag}{$address_data}}}} \
                     {eq{1}{${extract{on_spamassassin}{$address_data}}}} \
                     } {X-Spam-Flag: YES\nX-Spam-Score: $acl_m_spam_score\nVEXIM_SPAM_REPORT_HEADER_NAME: $acl_m_spam_report}{} }
   # using local_part_suffixes enables possibility to use user-"something" localparts

--- a/docs/debian-conf.d/router/249_vexim_ditch_routers
+++ b/docs/debian-conf.d/router/249_vexim_ditch_routers
@@ -47,7 +47,7 @@ ditch_spam_drop:
     driver = redirect
     allow_fail
     data = :blackhole:
-    condition = ${if >{$spam_score_int}{${lookup mysql{select users.sa_refuse * 10 from users,domains \
+    condition = ${if >={$spam_score_int}{${lookup mysql{select users.sa_refuse * 10 from users,domains \
         where localpart = '${quote_mysql:$local_part}' \
         and domain = '${quote_mysql:$domain}' \
         and users.on_spamassassin = '1' \
@@ -68,7 +68,7 @@ ditch_spam:
         and domains.enabled = '1' \
         and users.enabled = '1' \
         and users.domain_id = domains.domain_id}}
-    condition = ${if >{$spam_score_int}{${lookup mysql{select \
+    condition = ${if >={$spam_score_int}{${lookup mysql{select \
         users.sa_refuse * 10 from users,domains \
         where localpart = '${quote_mysql:$local_part}' \
         and domain = '${quote_mysql:$domain}' \

--- a/docs/debian-conf.d/router/250_vexim_virtual_domains
+++ b/docs/debian-conf.d/router/250_vexim_virtual_domains
@@ -55,7 +55,7 @@ virtual_domains:
   headers_add = ${if and { \
                     {match{$domain}{$original_domain}} \
                     {match{$local_part}{$original_local_part}} \
-                    {>{$spam_score_int}{${extract{sa_tag}{$address_data}}}} \
+                    {>={$spam_score_int}{${extract{sa_tag}{$address_data}}}} \
                     {eq{1}{${extract{on_spamassassin}{$address_data}}}} \
                     } {X-Spam-Flag: YES\nX-Spam-Score: $acl_m_spam_score\nVEXIM_SPAM_REPORT_HEADER_NAME: $acl_m_spam_report}{} }
   # using local_part_suffixes enables possibility to use user-"something" localparts


### PR DESCRIPTION
`sa_tag` and `sa_refuse` settings should be treated as minimum values to induce the effect, not as maximum values which do NOT induce it.
For example, if I have `sa_tag=20`, I expect all messages with spam score 2.0 or above tagged, as opposed to only messages above 2.0 being tagged.
Fixes #223