### PR TITLE
Give siteadmin user the ability to manage domains as a domain manager

### DIFF
--- a/vexim/config/authpostmaster.php
+++ b/vexim/config/authpostmaster.php
@@ -5,31 +5,56 @@
 
 	# some session debugging code
 	#print_r($_SESSION);
-	
+
 	# confirm we have the necessary session variables
 	if (!isset($_SESSION['user_id'])
 		|| !isset($_SESSION['domain_id'])
 		|| !isset($_SESSION['crypt'])
-		)		
+		)
 	{
-		header ("Location: index.php?login=failed"); 
-		die(); 
-	}	
-	
+		header ("Location: index.php?login=failed");
+		die();
+	}
+
+	$validateAsSiteadmin =
+		(    isset($siteadminManageDomains)
+		  && $siteadminManageDomains
+		  && 'siteadmin' === $_SESSION['username']
+		  && isset($_SESSION['siteadmin_domain_id'])
+		);
+	$domain_id = $validateAsSiteadmin ? $_SESSION['siteadmin_domain_id'] : $_SESSION['domain_id'];
+
 	# Match the session details to an admin account the domain of the postmaster
 	$query = "SELECT crypt FROM users WHERE user_id=:user_id AND domain_id=:domain_id AND admin='1';";
     $sth = $dbh->prepare($query);
-    $success = $sth->execute(array(':user_id'=>$_SESSION['user_id'], ':domain_id'=>$_SESSION['domain_id']));
+    $success = $sth->execute(array(':user_id'=>$_SESSION['user_id'], ':domain_id'=>$domain_id));
     if(!$success || ($sth->rowCount()!=1)) {
       header ("Location: index.php?login=failed");
       die();
     }
 	$row = $sth->fetch();
-	
+
 	# confirm the crypted password in the session matches the crypted password in the database for the user
 	if ($row['crypt'] != $_SESSION['crypt']) {
-		header ("Location: index.php?login=failed"); 
-		die(); 
+		header ("Location: index.php?login=failed");
+		die();
 	}
-	
-?>
+
+	if (isset($siteadminManageDomains)
+	    && $siteadminManageDomains
+	    && isset($_SESSION['username'])
+	    && 'siteadmin' === $_SESSION['username']
+	    && isset($_GET['manage_domain_id'])
+	    )
+	{
+		$query = "SELECT domain FROM domains WHERE domain_id=:domain_id;";
+		$sth = $dbh->prepare($query);
+		$success = $sth->execute(array(':domain_id'=>$_GET['manage_domain_id']));
+		if(!$success || ($sth->rowCount()!=1)) {
+			header ("Location: index.php?login=failed");
+			die();
+		}
+		$row = $sth->fetch();
+		$_SESSION['domain_id'] = $_GET['manage_domain_id'];
+		$_SESSION['domain'] = $row['domain'];
+	}

--- a/vexim/config/authsite.php
+++ b/vexim/config/authsite.php
@@ -2,42 +2,50 @@
 	include_once dirname(__FILE__) . '/variables.php';
 	include_once dirname(__FILE__) . '/functions.php';
 	include_once dirname(__FILE__) . '/httpheaders.php';
-	
+
 	# some session debugging code
 	#print_r($_SESSION);
-	
+
 	# confirm we have the necessary session variables
 	if (!isset($_SESSION['user_id'])
 		|| !isset($_SESSION['domain_id'])
 		|| !isset($_SESSION['crypt'])
-		)		
+		)
 	{
-		header ("Location: index.php?login=failed"); 
-		die(); 
+		header ("Location: index.php?login=failed");
+		die();
 	}
-	
-	if ($_SESSION['username'] != "siteadmin"){ 
-		header ("Location: index.php?login=failed"); 
-		die(); 
+
+	if ($_SESSION['username'] != "siteadmin"){
+		header ("Location: index.php?login=failed");
+		die();
 	}
-	
+
+	# reset to standard siteadmin domain
+	if (isset($siteadminManageDomains)
+	    && $siteadminManageDomains
+	    && isset($_SESSION['siteadmin_domain_id'])
+	    )
+	{
+		$_SESSION['domain_id'] = $_SESSION['siteadmin_domain_id'];
+		$_SESSION['domain'] = $_SESSION['siteadmin_domain'];
+	}
+
 	# Match the session details to the siteadmin account
-	$query = "SELECT crypt,domain FROM users,domains 
+	$query = "SELECT crypt,domain FROM users,domains
 		WHERE users.user_id=:user_id AND users.domain_id=:domain_id
 		AND localpart='siteadmin' AND domain='admin' AND users.domain_id=domains.domain_id;";
     $sth = $dbh->prepare($query);
     $success = $sth->execute(array(':user_id'=>$_SESSION['user_id'], ':domain_id'=>$_SESSION['domain_id']));
     if(!$success || ($sth->rowCount()!=1)) {
-		header ("Location: index.php?login=failed"); 
-		die(); 
+		header ("Location: index.php?login=failed");
+		die();
     }
 
     $row = $sth->fetch();
-	
+
 	# confirm the crypted password in the session matches the crypted password in the database for the siteadmin
 	if ($row['crypt'] !== $_SESSION['crypt']) {
-		header ("Location: index.php?login=failed"); 
-		die(); 
+		header ("Location: index.php?login=failed");
+		die();
 	}
-	
-?>

--- a/vexim/config/authsite.php
+++ b/vexim/config/authsite.php
@@ -16,7 +16,8 @@
 		die();
 	}
 
-	if ($_SESSION['username'] != "siteadmin"){
+	if ($_SESSION['username'] !== 'siteadmin')
+	{
 		header ("Location: index.php?login=failed");
 		die();
 	}

--- a/vexim/config/functions.php
+++ b/vexim/config/functions.php
@@ -26,7 +26,7 @@
     function password_strengthcheck($candidate)
     {
         global $passwordstrengthcheck;
-        
+
         if ( $passwordstrengthcheck == 0
           || preg_match_all('$\S*(?=\S{8,})(?=\S*[a-z])(?=\S*[A-Z])(?=\S*[\d])(?=\S*[\W])\S*$', $candidate)
           || preg_match_all('$\S*(?=\S{12,})(?=\S*[a-z])(?=\S*[A-Z])(?=\S*[\d])\S*$', $candidate)
@@ -34,7 +34,7 @@
           || (strlen($candidate)>20)
         ) {
             if (strtolower($candidate) <> strtolower($_POST['localpart'])
-                && strtolower($candidate) <> strtolower($_POST['username'])
+                && (!isset($_POST['username']) || strtolower($candidate) <> strtolower($_POST['username']))
                 )
             {
                 return TRUE;
@@ -55,7 +55,7 @@
 
  */
     }
-    
+
     /**
      * Check if a user already exists.
      *
@@ -63,20 +63,20 @@
      * exists.
      *
      * @param  mixed   $dbh         database to query
-     * @param  string  $localpart  
+     * @param  string  $localpart
      * @param  string  $domain_id
      * @param  string  $page       page to return to
      */
     function check_user_exists($dbh,$localpart,$domain_id,$page)
     {
-        $query = "SELECT COUNT(*) AS c 
-                  FROM   users 
+        $query = "SELECT COUNT(*) AS c
+                  FROM   users
                   WHERE  localpart=:localpart
                   AND    domain_id=:domain_id";
         $sth = $dbh->prepare($query);
         $sth->execute(array(':localpart'=>$localpart, ':domain_id'=>$domain_id));
         $row = $sth->fetch();
-        if ($row['c'] != 0) 
+        if ($row['c'] != 0)
         {
             header ("Location: $page?userexists=$localpart");
             die;
@@ -106,23 +106,23 @@
      *
      * @param  unknown  $flag  unknown
      */
-    function alpha_menu($flag) 
+    function alpha_menu($flag)
     {
         global $letter;	// needs to be available to the parent
-        if ($letter == 'all') 
+        if ($letter == 'all')
         {
             $letter = '';
         }
-        if ($flag) 
+        if ($flag)
         {
-            print "\n<p class='alpha'><a href='" . $_SERVER['PHP_SELF'] . 
+            print "\n<p class='alpha'><a href='" . $_SERVER['PHP_SELF'] .
                   "?LETTER=ALL' class='alpha'>ALL</a>&nbsp;&nbsp; ";
-            // loops through the alphabet. 
+            // loops through the alphabet.
             // For international alphabets, replace the string in the proper order
-            foreach (preg_split('//', _("ABCDEFGHIJKLMNOPQRSTUVWXYZ"), -1, 
-                                PREG_SPLIT_NO_EMPTY) as $i) 
+            foreach (preg_split('//', _("ABCDEFGHIJKLMNOPQRSTUVWXYZ"), -1,
+                                PREG_SPLIT_NO_EMPTY) as $i)
             {
-      	        print "<a href='" . $_SERVER['PHP_SELF'] . 
+      	        print "<a href='" . $_SERVER['PHP_SELF'] .
                       "?LETTER=$i' class='alpha'>$i</a>&nbsp; ";
             }
             print "</p>\n";

--- a/vexim/config/header.php
+++ b/vexim/config/header.php
@@ -114,6 +114,6 @@
   }
   if (isset($_GET['login']) && ($_GET['login'] == "failed")) { print _("Login failed"); }
 
-  if ($validateAsSiteadmin) print '<a href="/site.php" style="float:right; margin-right:20px;">siteadmin home</a>';
+  if ($validateAsSiteadmin) print '<a href="site.php" style="float:right; margin-right:20px;">siteadmin home</a>';
 
   print "</p></div>";

--- a/vexim/config/header.php
+++ b/vexim/config/header.php
@@ -1,9 +1,18 @@
 <?php
-  if (isset($_SESSION['domain_id'])) {
+  $validateAsSiteadmin =
+    (    isset($siteadminManageDomains)
+      && $siteadminManageDomains
+      && isset($_SESSION['username'])
+      && 'siteadmin' === $_SESSION['username']
+      && isset($_SESSION['siteadmin_domain_id']) );
+  $domain_id = $validateAsSiteadmin
+    ? $_SESSION['siteadmin_domain_id']
+    : (isset($_SESSION['domain_id']) ? $_SESSION['domain_id'] : null);
+  if (null !== $domain_id) {
     $headerquery = "SELECT domains.enabled AS domain, users.enabled AS user FROM users,domains
                     WHERE users.username=:username AND domains.domain_id=:domain_id AND users.domain_id=domains.domain_id;";
     $headerresult = $dbh->prepare($headerquery);
-    $headersuccess = $headerresult->execute(array(':username'=>$_SESSION['username'], ':domain_id'=>$_SESSION['domain_id']));
+    $headersuccess = $headerresult->execute(array(':username'=>$_SESSION['username'], ':domain_id'=>$domain_id));
     if ($headersuccess && $headerrow = $headerresult->fetch()) {
       if ($headerrow['domain'] === "0") {
         invalidate_session();
@@ -104,5 +113,7 @@
     print   _("-- Login is disabled. Please contact your administrator.");
   }
   if (isset($_GET['login']) && ($_GET['login'] == "failed")) { print _("Login failed"); }
+
+  if ($validateAsSiteadmin) print '<a href="/site.php" style="float:right; margin-right:20px;">siteadmin home</a>';
 
   print "</p></div>";

--- a/vexim/config/header.php
+++ b/vexim/config/header.php
@@ -114,6 +114,6 @@
   }
   if (isset($_GET['login']) && ($_GET['login'] == "failed")) { print _("Login failed"); }
 
-  if ($validateAsSiteadmin) print '<a href="site.php" style="float:right; margin-right:20px;">siteadmin home</a>';
+  if ($validateAsSiteadmin) print '<a href="site.php" id="SiteadminHome">siteadmin home</a>';
 
   print "</p></div>";

--- a/vexim/config/variables.php.example
+++ b/vexim/config/variables.php.example
@@ -57,6 +57,9 @@
   $uid = "90";
   $gid = "90";
   $postmasteruidgid = "yes";
+  
+  /* Allow the siteadmin user to manage domains? */
+  $siteadminManageDomains = true;
 
   /* The location of your mailstore for new domains.
      Make sure the directory belongs to the configured $uid/$gid! */

--- a/vexim/login.php
+++ b/vexim/login.php
@@ -34,7 +34,7 @@
   $cryptedpass = crypt_password($_POST['crypt'], $row['crypt']);
 
 //  Some debugging prints. They help when you don't know why auth is failing.
-/*  
+/*
   print $query. "<br>\n";;
   print $row['username']. "<br>\n";
   print $_POST['username'] . "<br>\n";
@@ -42,7 +42,7 @@
   print $row['crypt'] . "<br>\n";
   print $cryptscheme . "<br>\n";
   print $cryptedpass . "<br>\n";
-*/  
+*/
 
   # if they have the wrong password bail out
   if ($cryptedpass !== $row['crypt']) {
@@ -67,6 +67,14 @@
   $_SESSION['domain'] = $row['domain'];
   $_SESSION['crypt'] = $row['crypt'];
   $_SESSION['user_id'] = $row['user_id'];
+
+  if (isset($siteadminManageDomains)
+      && $siteadminManageDomains
+      && 'siteadmin' === $row['username']
+  ) {
+    $_SESSION['siteadmin_domain_id'] = $row['domain_id'];
+    $_SESSION['siteadmin_domain'] = $row['domain'];
+  }
 
   # redirect the user to the correct starting page
   if (($row['admin'] == '1') && ($row['type'] == 'site')) {

--- a/vexim/site.php
+++ b/vexim/site.php
@@ -95,7 +95,7 @@
           <?php
             if (isset($siteadminManageDomains) && $siteadminManageDomains) {
           ?>
-            <td><a href="/admin.php?manage_domain_id=<?php echo $row['domain_id']; ?>">manage</a></td>
+            <td><a href="admin.php?manage_domain_id=<?php echo $row['domain_id']; ?>">manage</a></td>
           <?php
             }
           ?>

--- a/vexim/site.php
+++ b/vexim/site.php
@@ -40,7 +40,7 @@
       <input type="submit" name="search"
         value="<?php echo _('search'); ?>">
     </form>
-    <table>
+    <table class="zebra">
       <tr>
         <th></th>
         <th><?php echo _('Local domains'); ?></th>
@@ -92,6 +92,13 @@
             }
           ?>
             <td><?php echo $row['count']; ?></td>
+          <?php
+            if (isset($siteadminManageDomains) && $siteadminManageDomains) {
+          ?>
+            <td><a href="/admin.php?manage_domain_id=<?php echo $row['domain_id']; ?>">manage</a></td>
+          <?php
+            }
+          ?>
            </tr>
           <?php
         }
@@ -157,9 +164,9 @@
           </tr>
       <?php
         }
-		
+
 		# display status of $AllowUserLogin
-		echo '<tr><td colspan="3">&nbsp;</td></tr>';       
+		echo '<tr><td colspan="3">&nbsp;</td></tr>';
 		if($AllowUserLogin){
 		    echo '<tr><td colspan="3">'._('Standard user accounts are currently able to login and change their own personal details').'.</td></tr>';
 		}else{

--- a/vexim/style.css
+++ b/vexim/style.css
@@ -50,6 +50,10 @@ table,tr,td,th {
 	text-align: left;
 }
 
+table.zebra tr:nth-child(even) {
+	background-color: #f0f0f0;
+}
+
 td.check {
 	text-align: center;
 }

--- a/vexim/style.css
+++ b/vexim/style.css
@@ -129,6 +129,12 @@ body>#Header {height:28px;}
   font-size: 12pt;
   color: #09c;
 }
+
+#SiteadminHome {
+  float: right;
+  margin-right: 20px;
+}
+
 #Content {
 	margin: 0px 50px 50px 250px;
 	padding:10px;


### PR DESCRIPTION
For your consideration, this branch has the following changes:

Primarily, it (optionally) grants the `siteadmin` user the capability to manage each domain as though they were the domain manager. This is accessed via the domains table at `site.php` using the added "manage" link. Clicking "manage" transfers the `siteadmin` to the `admin.php` page with the powers of a domain manager for the chosen site. When the `siteadmin` returns to a siteadmin page (i.e., a page that includes `authsite.php`, they are "logged out" of the domain and return to being the `siteadmin` user.

Secondarily, it has a few other changes in it:
1. Fixed a warning message when `password_strengthcheck` is called with no `username` in `$_POST`, e.g. from `adminuseradd.php`.
2. Added some zebra striping to the domains table at `site.php`.
3. Some trailing whitespace is removed. (As a reminder, append `?w=1` to the compare url to see a diff with the whitespace changes ignored.)
4. Some final closing php tags are removed. (Per https://secure.php.net/manual/en/language.basic-syntax.phptags.php)
