### PR TITLE
Delete domainaliases with domain, fix https://github.com/Exim4U/src/i…

### DIFF
--- a/vexim/sitedelete.php
+++ b/vexim/sitedelete.php
@@ -24,17 +24,23 @@
       $usrdelquery = "DELETE FROM blocklists WHERE domain_id=:domain_id";
       $usrdelsth = $dbh->prepare($usrdelquery);
       $usrdelsuccess = $usrdelsth->execute(array(':domain_id'=>$_POST['domain_id']));
-      // if we were successful, delete the domain itself
-      if ($usrdelsuccess) {
-        $domdelquery = "DELETE FROM domains WHERE domain_id=:domain_id";
-        $domdelsth = $dbh->prepare($domdelquery);
-        $domdelsuccess = $domdelsth->execute(array(':domain_id'=>$_POST['domain_id']));
-        // If everything went well, redirect to a success page.
+      // if we were successful, delete the domain's aliases
+      if($usrdelsuccess) {
+	$aliasdelquery = "DELETE FROM domainalias WHERE domain_id=:domain_id";
+        $aliasdelsth = $dbh->prepare($aliasdelquery);
+        $aliasdelsuccess = $aliasdelsth->execute(array(':domain_id'=>$_POST['domain_id']));
+        // if we were successful, delete the domain itself
+        if ($aliasdelsuccess) {
+          $domdelquery = "DELETE FROM domains WHERE domain_id=:domain_id";
+          $domdelsth = $dbh->prepare($domdelquery);
+          $domdelsuccess = $domdelsth->execute(array(':domain_id'=>$_POST['domain_id']));
+          // If everything went well, redirect to a success page.
 	    if ($domdelsuccess) {
 	      header ("Location: site.php?deleted={$_POST['domain']}");
 	      die;
 	    }
-      }
+        }
+      }	
     } else {
       header ("Location: site.php?faildeleted={$_POST['domain']}");
       die;


### PR DESCRIPTION
…ssues/3

I found this report downstream: https://github.com/Exim4U/src/issues/3

With a current database scheme, it should be deleted anyhow (https://github.com/vexim/vexim2/blob/master/setup/mysql.sql#L138-L149) but perhaps not everybody is updated, and we also have the delete statements for users and blocklists of a domain despite the new db-settings.