### PR TITLE
fix regex for filenames including .com domains

### DIFF
--- a/docs/vexim-acl-check-mime.conf
+++ b/docs/vexim-acl-check-mime.conf
@@ -10,7 +10,7 @@
   deny
         condition = ${if match \
                         {${lc:$mime_filename}} \
-                        {\N(?i)\.(exe|com|ade|adep|adp|bas|bat|chm|cmd|cnf|com|cpl|crt|dll|hlp|hta|inf|ins|isp|js|jse|lnk|mad|maf|mag|mam|maq|mar|mas|matmav|maw|ocx|pcd|pif|reg|scf|scr|sct|vbe|vbs|wsc|wsf|wsh|url|xnk)\N} \
+                        {\N(?i)\.(exe|com|ade|adep|adp|bas|bat|chm|cmd|cnf|com|cpl|crt|dll|hlp|hta|inf|ins|isp|js|jse|lnk|mad|maf|mag|mam|maq|mar|mas|matmav|maw|ocx|pcd|pif|reg|scf|scr|sct|vbe|vbs|wsc|wsf|wsh|url|xnk)$\N} \
                         {1}{0}}
         message = Blacklisted file extension detected in "$mime_filename". If you legitimately need to send these files please use a compressed archive or a file exchange provider.
         log_message = DENY: Blacklisted extension ("$mime_filename")


### PR DESCRIPTION
add a $ to regex to not filter filenames including a domainname like used in dmarc reports.
fixes #251