### PR TITLE
Use `htmlspecialchars()` to escape user-provided vars before output

### DIFF
--- a/vexim/adminaliasadd.php
+++ b/vexim/adminaliasadd.php
@@ -33,7 +33,7 @@
             <td><?php echo _('Address'); ?>:</td>
             <td>
               <input name="localpart" type="text" class="textfield">@
-              <?php print $_SESSION['domain']; ?>
+              <?php print htmlspecialchars($_SESSION['domain']); ?>
             </td>
           </tr>
           <tr>

--- a/vexim/adminaliasdelete.php
+++ b/vexim/adminaliasdelete.php
@@ -44,8 +44,8 @@
           <tr>
             <td colspan="2">
               <?php printf (_('Please confirm deleting alias %s@%s'),
-                $_GET['localpart'] ,
-                $_SESSION['domain']);
+                htmlspecialchars($_GET['localpart']),
+                htmlspecialchars($_SESSION['domain']));
               ?>:
             </td>
           </tr>
@@ -53,8 +53,8 @@
             <td>
               <input name='confirm' type='radio' value='cancel' checked>
               <b><?php printf (_('Do Not Delete %s@%s'),
-                $_GET['localpart'],
-                $_SESSION['domain']);
+                htmlspecialchars($_GET['localpart']),
+                htmlspecialchars($_SESSION['domain']));
               ?></b>
             </td>
           </tr>
@@ -62,19 +62,19 @@
             <td>
               <input name='confirm' type='radio' value='1'>
               <b><?php printf (_('Delete %s@%s'),
-                $_GET['localpart'],
-                $_SESSION['domain']);
+                htmlspecialchars($_GET['localpart']),
+                htmlspecialchars($_SESSION['domain']));
               ?></b>
             </td>
           </tr>
           <tr>
             <td>
               <input name='domain' type='hidden'
-                value='<?php echo $_SESSION['domain']; ?>'>
+                value='<?php echo htmlspecialchars($_SESSION['domain']); ?>'>
               <input name='user_id' type='hidden'
-                value='<?php echo $_GET['user_id']; ?>'>
+                value='<?php echo htmlspecialchars($_GET['user_id']); ?>'>
               <input name='localpart' type='hidden'
-                value='<?php echo $_GET['localpart']; ?>'>
+                value='<?php echo htmlspecialchars($_GET['localpart']); ?>'>
               <input name='submit' type='submit'
                 value='<?php echo _('Continue'); ?>'>
             </td>

--- a/vexim/adminfail.php
+++ b/vexim/adminfail.php
@@ -48,7 +48,7 @@
               . '">'
               . $row['localpart']
               . '@'
-              . $_SESSION['domain']
+              . htmlspecialchars($_SESSION['domain'])
               . '</a></td>';
             print '</tr>';
           }

--- a/vexim/adminfailadd.php
+++ b/vexim/adminfailadd.php
@@ -24,7 +24,7 @@
 	    <td><?php echo _('Address to fail'); ?>:</td>
             <td>
               <input name="localpart" type="text" class="textfield" autofocus>@
-              <?php print $_SESSION['domain']; ?>
+              <?php print htmlspecialchars($_SESSION['domain']); ?>
             </td>
 	  </tr>
 	  <tr>

--- a/vexim/adminfailchange.php
+++ b/vexim/adminfailchange.php
@@ -41,11 +41,11 @@
 	    <td>
               <input name="localpart" type="text"
                 value="<?php print $row['localpart']; ?>" class="textfield" autofocus>@
-              <?php print $_SESSION['domain']; ?>
+              <?php print htmlspecialchars($_SESSION['domain']); ?>
             </td>
 	    <td>
               <input name="user_id" type="hidden"
-                value="<?php print $_GET['user_id']; ?>" class="textfield">
+                value="<?php print htmlspecialchars($_GET['user_id']); ?>" class="textfield">
             </td>
           </tr>
 	  <tr>

--- a/vexim/admingroupchange.php
+++ b/vexim/admingroupchange.php
@@ -43,9 +43,9 @@
           <td>
             <input name="localpart" type="text"
               value="<?php echo $row['name']; ?>"class="textfield" autofocus>@
-              <?php echo $_SESSION['domain']; ?>
+              <?php echo htmlspecialchars($_SESSION['domain']); ?>
             <input name="group_id" type="hidden"
-              value="<?php echo $_GET['group_id']; ?>" class="textfield">
+              value="<?php echo htmlspecialchars($_GET['group_id']); ?>" class="textfield">
           </td>
         </tr>
         <tr>
@@ -96,7 +96,7 @@
               ?>
               <tr>
                 <td class="trash">
-                  <a href="admingroupcontentdeletesubmit.php?group_id=<?php echo $_GET['group_id'];
+                  <a href="admingroupcontentdeletesubmit.php?group_id=<?php echo htmlspecialchars($_GET['group_id']);
 					?>&member_id=<?php echo $row['member_id'];
 					?>&localpart=<?php echo $grouplocalpart;
 					?>">
@@ -107,7 +107,7 @@
                   </a>
                 </td>
                 <td><?php echo $row['realname']; ?></td>
-                <td><?php echo $row['localpart'].'@'.$_SESSION['domain']; ?></td>
+                <td><?php echo $row['localpart'].'@'.htmlspecialchars($_SESSION['domain']); ?></td>
                 <td>
                   <?php
                     if($row['enabled']='1') {
@@ -138,7 +138,7 @@
             <td><?php echo _('Add Member'); ?></td>
             <td>
               <input name="group_id" type="hidden"
-                value="<?php echo $_GET['group_id']; ?>" class="textfield">
+                value="<?php echo htmlspecialchars($_GET['group_id']); ?>" class="textfield">
               <input name="localpart" type="hidden"
                 value="<?php echo $grouplocalpart; ?>" class="textfield">
               <select name="usertoadd">
@@ -153,7 +153,7 @@
                 ?>
                   <option value="<?php echo $row['user_id'];
 					?>"><?php echo $row['realname'];
-					?> (<?php echo $row['localpart'].'@'.$_SESSION['domain']; ?>)</option>
+					?> (<?php echo $row['localpart'].'@'.htmlspecialchars($_SESSION['domain']); ?>)</option>
                 <?php
                   }
                 ?>

--- a/vexim/admingroupdelete.php
+++ b/vexim/admingroupdelete.php
@@ -59,8 +59,8 @@
           <tr>
             <td colspan="2">
               <?php printf (_('Please confirm deleting group %s@%s'),
-                $_GET['localpart'],
-                $_SESSION['domain']);
+                htmlspecialchars($_GET['localpart']),
+                htmlspecialchars($_SESSION['domain']));
               ?>:
             </td>
           </tr>
@@ -68,8 +68,8 @@
             <td>
               <input name='confirm' type='radio' value='cancel' checked>
               <b><?php printf (_('Do Not Delete %s@%s'),
-                $_GET['localpart'],
-                $_SESSION['domain']);
+                htmlspecialchars($_GET['localpart']),
+                htmlspecialchars($_SESSION['domain']));
               ?></b>
             </td>
           </tr>
@@ -77,19 +77,19 @@
             <td>
               <input name='confirm' type='radio' value='1'><b>
               <?php printf (_('Delete %s@%s'),
-                $_GET['localpart'],
-                $_SESSION['domain']);
+                htmlspecialchars($_GET['localpart']),
+                htmlspecialchars($_SESSION['domain']));
               ?></b>
             </td>
           </tr>
           <tr>
             <td>
               <input name='domain' type='hidden'
-                value='<?php echo $_SESSION['domain']; ?>'>
+                value='<?php echo htmlspecialchars($_SESSION['domain']); ?>'>
               <input name='group_id' type='hidden'
-                value='<?php echo $_GET['group_id']; ?>'>
+                value='<?php echo htmlspecialchars($_GET['group_id']); ?>'>
               <input name='localpart' type='hidden'
-                value='<?php echo $_GET['localpart']; ?>'>
+                value='<?php echo htmlspecialchars($_GET['localpart']); ?>'>
               <input name='submit' type='submit'
                 value='<?php echo _('Continue'); ?>'>
             </td>

--- a/vexim/adminuser.php
+++ b/vexim/adminuser.php
@@ -52,7 +52,7 @@
       <form name="search" method="post" action="adminuser.php">
         <?php echo _('Search'); ?>:
         <input type="text" size="20" name="searchfor"
-          value="<?php echo $_POST['searchfor']; ?>" class="textfield">
+          value="<?php echo htmlspecialchars($_POST['searchfor']); ?>" class="textfield">
         <?php echo _('in'); ?>
         <select name="field" class="textfield">
           <option value="realname" <?php if ($_POST['field'] == 'realname') {
@@ -111,7 +111,7 @@
             . ' '
             . $row['realname']
             . '">'
-            . $row['localpart'] .'@'. $_SESSION['domain']
+            . $row['localpart'] .'@'. htmlspecialchars($_SESSION['domain'])
             . '</a></td>';
           print '<td class="check">';
           if ($row['admin'] == 1) {

--- a/vexim/adminuserchange.php
+++ b/vexim/adminuserchange.php
@@ -56,7 +56,7 @@
             <input type="text" size="25" name="realname"
               value="<?php print $row['realname']; ?>" class="textfield" autofocus>
             <input name="user_id" type="hidden"
-              value="<?php print $_GET['user_id']; ?>">
+              value="<?php print htmlspecialchars($_GET['user_id']); ?>">
           </td>
         </tr>
         <tr>
@@ -300,7 +300,7 @@
               print " checked ";
             } ?>>
             <input name="user_id" type="hidden"
-              value="<?php print $_GET['user_id']; ?>">
+              value="<?php print htmlspecialchars($_GET['user_id']); ?>">
             <input name="localpart" type="hidden"
               value="<?php print $row['localpart']; ?>">
           </td>
@@ -373,9 +373,9 @@
           <td>
             <input name="blockval" type="text" size="25" class="textfield">
             <input name="user_id" type="hidden"
-              value="<?php print $_GET['user_id']; ?>">
+              value="<?php print htmlspecialchars($_GET['user_id']); ?>">
             <input name="localpart" type="hidden"
-              value="<?php print $_GET['localpart']; ?>">
+              value="<?php print htmlspecialchars($_GET['localpart']); ?>">
             <input name="color" type="hidden" value="black">
           </td>
         </tr>
@@ -400,11 +400,11 @@
             <tr>
               <td>
                 <a href="adminuserblocksubmit.php?action=delete&user_id=<?php
-					print $_GET['user_id']
+					print htmlspecialchars($_GET['user_id'])
 					. '&block_id='
 					. $blockrow['block_id']
 					.'&localpart='
-					. $_GET['localpart'];?>">
+					. htmlspecialchars($_GET['localpart']);?>">
                   <img class="trash" title="Delete" src="images/trashcan.gif"
                     alt="trashcan">
                 </a>

--- a/vexim/siteadd.php
+++ b/vexim/siteadd.php
@@ -193,7 +193,7 @@
             </td>
             <td colspan="2">
               <input name="type" type="hidden"
-                value="<?php print $_GET['type']; ?>">
+                value="<?php print htmlspecialchars($_GET['type']); ?>">
               <input name="admin" type="hidden" value="1">
               <input name="submit" type="submit"
                 value="<?php echo _('Submit'); ?>">

--- a/vexim/sitechange.php
+++ b/vexim/sitechange.php
@@ -48,8 +48,8 @@ include_once dirname(__FILE__) . "/config/httpheaders.php";
                     ?>
                 </td>
                 <td>
-                    <input name="domain_id" type="hidden" value="<?php print $_GET['domain_id']; ?>">
-                    <input name="domain" type="hidden" value="<?php print $_GET['domain']; ?>">
+                    <input name="domain_id" type="hidden" value="<?php print htmlspecialchars($_GET['domain_id']); ?>">
+                    <input name="domain" type="hidden" value="<?php print htmlspecialchars($_GET['domain']); ?>">
                 </td>
             </tr>
             <tr>
@@ -116,8 +116,8 @@ include_once dirname(__FILE__) . "/config/httpheaders.php";
                 <td><?php echo _("Enabled"); ?>:</td>
                 <td><input type="checkbox" name="enabled" <?php if ($row['enabled'] == 1) {print "checked";} ?>></td>
                 <td>
-                    <input name="domain_id" type="hidden" value="<?php print $_GET['domain_id']; ?>">
-                    <input name="domain" type="hidden" value="<?php print $_GET['domain']; ?>">
+                    <input name="domain_id" type="hidden" value="<?php print htmlspecialchars($_GET['domain_id']); ?>">
+                    <input name="domain" type="hidden" value="<?php print htmlspecialchars($_GET['domain']); ?>">
                 </td>
             </tr>
             <tr>
@@ -128,9 +128,9 @@ include_once dirname(__FILE__) . "/config/httpheaders.php";
         </table>
     </form><br>
     <form name="allusers" method="post" action="sitechangesubmit.php">
-            <input name="allusers" type="hidden" value="<?php print $_GET['domain_id']; ?>">
-            <input name="domain_id" type="hidden" value="<?php print $_GET['domain_id']; ?>">
-            <input name="domain" type="hidden" value="<?php print $_GET['domain']; ?>">
+            <input name="allusers" type="hidden" value="<?php print htmlspecialchars($_GET['domain_id']); ?>">
+            <input name="domain_id" type="hidden" value="<?php print htmlspecialchars($_GET['domain_id']); ?>">
+            <input name="domain" type="hidden" value="<?php print htmlspecialchars($_GET['domain']); ?>">
         <table align="center">
             <tr>
                 <td colspan="2"><h4><?php echo _("Modify SpamAssassin/Antivirus for all users").":"; ?></h4></td>

--- a/vexim/sitedelete.php
+++ b/vexim/sitedelete.php
@@ -87,18 +87,18 @@
     <div id='Content'>
       <form name='domaindelete' method='post' action='sitedelete.php'>
 	<table align="center">
-	  <tr><td colspan='2'><?php printf (_("Please confirm deleting domain %s."), $_GET['domain']); ?>:</td></tr>
+	  <tr><td colspan='2'><?php printf (_("Please confirm deleting domain %s."), htmlspecialchars($_GET['domain'])); ?>:</td></tr>
 	  <?php if (($_GET['type'] != "relay") && ($_GET['type'] != "alias")) {
 		print   "<tr><td colspan='2'>";
-        printf (ngettext("There is currently <b>%1\$d</b> account in domain %2\$s", "There are currently <b>%1\$d</b> accounts in domain %2\$s", $row['count']), $row['count'], $_GET['domain']);
+        printf (ngettext("There is currently <b>%1\$d</b> account in domain %2\$s", "There are currently <b>%1\$d</b> accounts in domain %2\$s", $row['count']), $row['count'], htmlspecialchars($_GET['domain']));
         print   "</td></tr>";
 	     }
 	  ?>
-	  <tr><td><input name='confirm' type='radio' value='cancel' checked><b> <?php printf (_("Do Not Delete %s"), $_GET['domain']); ?></b></td></tr>
-	  <tr><td><input name='confirm' type='radio' value='1'><b> <?php printf (_("Delete %s"), $_GET['domain']); ?></b></td></tr>
-	  <tr><td><input name='domain_id' type='hidden' value='<?php print $_GET['domain_id']; ?>'>
-	  	  <input name='domain' type='hidden' value='<?php print $_GET['domain']; ?>'>
-	  	  <input name='type' type='hidden' value='<?php print $_GET['type']; ?>'>
+	  <tr><td><input name='confirm' type='radio' value='cancel' checked><b> <?php printf (_("Do Not Delete %s"), htmlspecialchars($_GET['domain'])); ?></b></td></tr>
+	  <tr><td><input name='confirm' type='radio' value='1'><b> <?php printf (_("Delete %s"), htmlspecialchars($_GET['domain'])); ?></b></td></tr>
+	  <tr><td><input name='domain_id' type='hidden' value='<?php print htmlspecialchars($_GET['domain_id']); ?>'>
+	  	  <input name='domain' type='hidden' value='<?php print htmlspecialchars($_GET['domain']); ?>'>
+	  	  <input name='type' type='hidden' value='<?php print htmlspecialchars($_GET['type']); ?>'>
 		  <input name='submit' type='submit' value='<?php echo _("Continue"); ?>'></td></tr>
 	</table>
       </form>

--- a/vexim/userchange.php
+++ b/vexim/userchange.php
@@ -34,7 +34,7 @@
       <form name="userchange" method="post" action="userchangesubmit.php">
         <table align="center">
 	  <tr><td><?php echo _("Name"); ?>:</td><td><input name="realname" type="text" value="<?php print $row['realname']; ?>" class="textfield" autofocus></td></tr>
-	  <tr><td><?php echo _("Email Address"); ?>:</td><td><?php print $row['localpart']."@".$_SESSION['domain']; ?></td>
+	  <tr><td><?php echo _("Email Address"); ?>:</td><td><?php print $row['localpart']."@".htmlspecialchars($_SESSION['domain']); ?></td>
 	  <tr><td><?php echo _("Password"); ?>:</td><td><input name="clear" type="password" class="textfield"></td></tr>
 	  <tr><td class="padafter"><?php echo _("Verify Password"); ?>:</td><td><input name="vclear" type="password" class="textfield"></td></tr>
    	  <tr><td colspan="2"><b><?php echo _("Note:"); ?></b> <?php echo _("Attempting to set blank passwords does not work!"); ?><td></tr>


### PR DESCRIPTION
Fixes #271
Fixes #272