### PR TITLE
Revert max retry time to 4 days

### DIFF
--- a/docs/configure
+++ b/docs/configure
@@ -1072,7 +1072,7 @@ begin retry
 # Domain               Error       Retries
 # ------               -----       -------
 
-*                      *           F,2h,15m; G,16h,1h,1.5; F,14d,6h
+*                      *           F,2h,15m; G,16h,1h,1.5; F,4d,6h
 
 
 


### PR DESCRIPTION
If you have a typo in the mail address or some other fail reason, you get a lot of mails. By default, exim uses 4 days, it was changed to 14 days by this commit: https://github.com/vexim/vexim2/commit/1a826792d86ee2c806464d6c697f70fe6a5fef85

4 days seems more reasonable for a system that is supposed to be connected all the time, it should be enough to cover most temporary problems. Not sure if that was changed by accident?