### PR TITLE
Dev docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,3 +242,9 @@ There are many POP3 and IMAP daemons available. Some that we have found that wor
 Dovecot provides more features (server-side sieve filters) and is more performant on larger setups.
 
 **UPGRADING:** If you are upgrading, you will need to update your configs for your POP/IMAP daemons, as the database layout has changed. You should be able to follow the above instructions without problem.
+
+## Docker Compose setup
+
+Minimalistic Docker Compose setup is provided in this repository. This setup is only meant for development, not for production use. It is configured to mount `vexim/config/variables.php.example` file as `variables.php`. Additionally, it will execute `setup/mysql.sql` during first boot, so **make note of the initial siteadmin credentials** which will be echoed by the db container among other output.
+
+Upon boot, Vexim UI will be available on http://localhost, and MySQL database on localhost:3306. Both ports can be overridden by setting `WEB_PORT` and/or `MYSQL_PORT` environment variables when running `docker compose`.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,53 @@
+version: '3'
+
+services:
+  db:
+    image: mysql:5.7
+    restart: on-failure
+    ports:
+      - "${MYSQL_PORT:-3306}:3306"
+    environment:
+      MYSQL_ROOT_PASSWORD: ''
+      MYSQL_DATABASE: 'vexim'
+      MYSQL_USER: 'vexim'
+      MYSQL_PASSWORD: 'CHANGE'
+      MYSQL_ALLOW_EMPTY_PASSWORD: 'yes'
+    volumes:
+      - db_data:/var/lib/mysql:rw
+      - ./setup/mysql.sql:/docker-entrypoint-initdb.d/mysql.sql:ro,cached
+
+  php:
+    build: docker/php
+    restart: on-failure
+    user: '${UID:-1000}'
+    volumes:
+      - mail_dir:/var/vmail:rw
+      - ./docker/php/xdebug.ini:/usr/local/etc/php/conf.d/xdebug.ini:ro,cached
+      - ./docker/php/timezone.ini:/usr/local/etc/php/conf.d/timezone.ini:ro,cached
+      - ./vexim:/srv/app:ro,cached
+      - ./vexim/config/variables.php.example:/srv/app/config/variables.php:ro,cached
+    extra_hosts:
+      - host.docker.internal:host-gateway
+    environment:
+      PHP_IDE_CONFIG: '${PHP_IDE_CONFIG:-serverName=vexim}'
+    depends_on:
+      - db
+    links:
+      - db
+
+  nginx:
+    image: nginx:1-alpine-slim
+    restart: on-failure
+    ports:
+      - "${WEB_PORT:-80}:80"
+    volumes:
+      - ./vexim:/srv/app:ro,cached
+      - ./docker/nginx/default.conf:/etc/nginx/conf.d/default.conf:ro,cached
+    depends_on:
+      - php
+    links:
+      - php
+
+volumes:
+  db_data:
+  mail_dir:

--- a/docker/nginx/default.conf
+++ b/docker/nginx/default.conf
@@ -1,0 +1,16 @@
+server {
+    listen 80;
+
+    error_log /dev/stderr debug;
+    access_log /dev/stdout;
+
+    root /srv/app;
+    index index.php;
+    try_files $uri $uri/ /index.php?$query_string;
+
+    location ~ \.php$ {
+        fastcgi_pass php:9000;
+        include fastcgi_params;
+        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+    }
+}

--- a/docker/php/Dockerfile
+++ b/docker/php/Dockerfile
@@ -1,0 +1,8 @@
+FROM php:8.1-fpm-alpine
+
+COPY --from=mlocati/php-extension-installer /usr/bin/install-php-extensions /usr/local/bin/
+
+RUN install-php-extensions pdo pdo_mysql gettext xdebug
+RUN cp $PHP_INI_DIR/php.ini-development $PHP_INI_DIR/php.ini
+
+WORKDIR /srv/app/

--- a/docker/php/Dockerfile
+++ b/docker/php/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.2-fpm-alpine
+FROM php:8.3-fpm-alpine
 
 COPY --from=mlocati/php-extension-installer /usr/bin/install-php-extensions /usr/local/bin/
 

--- a/docker/php/Dockerfile
+++ b/docker/php/Dockerfile
@@ -2,7 +2,9 @@ FROM php:8.1-fpm-alpine
 
 COPY --from=mlocati/php-extension-installer /usr/bin/install-php-extensions /usr/local/bin/
 
-RUN install-php-extensions pdo pdo_mysql gettext xdebug
-RUN cp $PHP_INI_DIR/php.ini-development $PHP_INI_DIR/php.ini
+RUN addgroup -S -g 90 vexim && \
+    adduser -S -u 90 -G vexim -h /var/vmail vexim && \
+    cp $PHP_INI_DIR/php.ini-development $PHP_INI_DIR/php.ini && \
+    install-php-extensions pdo pdo_mysql gettext xdebug
 
 WORKDIR /srv/app/

--- a/docker/php/Dockerfile
+++ b/docker/php/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.1-fpm-alpine
+FROM php:8.2-fpm-alpine
 
 COPY --from=mlocati/php-extension-installer /usr/bin/install-php-extensions /usr/local/bin/
 

--- a/docker/php/timezone.ini
+++ b/docker/php/timezone.ini
@@ -1,1 +1,1 @@
-date.timezone = 'Europe/Vilnius'
+date.timezone = 'UTC'

--- a/docker/php/timezone.ini
+++ b/docker/php/timezone.ini
@@ -1,0 +1,1 @@
+date.timezone = 'Europe/Vilnius'

--- a/docker/php/xdebug.ini
+++ b/docker/php/xdebug.ini
@@ -1,0 +1,4 @@
+[xdebug]
+xdebug.client_host=host.docker.internal
+xdebug.start_with_request=yes
+xdebug.mode=debug

--- a/vexim/config/variables.php.example
+++ b/vexim/config/variables.php.example
@@ -2,7 +2,7 @@
   /* SQL Database login information */
   include_once dirname(__FILE__) . "/i18n.php";
 
-  $sqlserver = "localhost";
+  $sqlserver = "db"; // Set this to your database server hostname or IP address.
   $sqltype = "mysql";
   $sqldb = "vexim";
   $sqluser = "vexim";


### PR DESCRIPTION
This adds a Docker Compose setup, which should make it easier to test our PHP changes/pull requests locally.

The only change to existing files is that in `variables.php.example`, where `localhost` has been replaced with `db` as database host name. I did this because I'm mounting that example file as `variables.php` in the container, and of course the database is hosted in a separate container, so `localhost` doesn't work in that case.

Kudos to my friend and ex-coworker @ievaskyriene for initial work on this feature.