### PR TITLE
Update userchangesubmit.php

### DIFF
--- a/vexim/userchangesubmit.php
+++ b/vexim/userchangesubmit.php
@@ -35,8 +35,8 @@
   $sth = $dbh->prepare($query);
   $sth->execute(array(':domain_id'=>$_SESSION['domain_id']));
   $row = $sth->fetch();
-  if ((isset($_POST['on_avscan'])) && ($row['avscan'] === '1')) {$_POST['on_avscan'] = 1;} else {$_POST['on_avscan'] = 0;}
-  if ((isset($_POST['on_spamassassin'])) && ($row['spamassassin'] === '1')) {$_POST['on_spamassassin'] = 1;} else {$_POST['on_spamassassin'] = 0;}
+  $_POST['on_avscan'] = (isset($_POST['on_avscan']) && $row['avscan'] == '1') ? 1 : 0;
+  $_POST['on_spamassassin'] = (isset($_POST['on_spamassassin']) && $row['spamassassin'] == '1') ? 1 : 0;
   if (isset($_POST['maxmsgsize']) && $row['maxmsgsize']!=='0') {
     if ($_POST['maxmsgsize']<=0 || $_POST['maxmsgsize']>$row['maxmsgsize']) {
       $_POST['maxmsgsize']=$row['maxmsgsize'];


### PR DESCRIPTION
Fix $_POST on_avscan and on_spamassassin checks condition on user save settings.
On my install with mysql 8 and php82 User save settings is incomplete.
Unavailable to save on_avscan and on_spamassassin $_POST params, because getting `int` from db, but checking condition in code accept `string` only.
This commit is fix checking conditions `$value === '1'` to simplest `$value == '1'`