### PR TITLE
Update vexim-acl-check-rcpt.conf

### DIFF
--- a/docs/vexim-acl-check-rcpt.conf
+++ b/docs/vexim-acl-check-rcpt.conf
@@ -67,4 +67,4 @@
 # To use a DNSBL the best would be to set up a caching dns server (e.g. unbound) because there is
 # often a rate limit that you will hit when using public DNS servers.
   deny    message       = DNSBL listed at $dnslist_domain\n$dnslist_text
-          dnslists      = zen.spamhaus.org:ix.dnsbl.manitu.net
+          dnslists      = zen.spamhaus.org


### PR DESCRIPTION
Nixspam list is discontinued:
https://hostblogger.de/blog/archives/7353-Die-AEra-der-ix.dnsbl.manitu.net-geht-zu-Ende.html