### PR TITLE
Escape PHP_SELF and search input to prevent reflected XSS

### DIFF
--- a/vexim/config/functions.php
+++ b/vexim/config/functions.php
@@ -115,14 +115,14 @@
         }
         if ($flag)
         {
-            print "\n<p class='alpha'><a href='" . $_SERVER['PHP_SELF'] .
+            print "\n<p class='alpha'><a href='" . html_escape($_SERVER['PHP_SELF']) .
                   "?LETTER=ALL' class='alpha'>ALL</a>&nbsp;&nbsp; ";
             // loops through the alphabet.
             // For international alphabets, replace the string in the proper order
             foreach (preg_split('//', _("ABCDEFGHIJKLMNOPQRSTUVWXYZ"), -1,
                                 PREG_SPLIT_NO_EMPTY) as $i)
             {
-      	        print "<a href='" . $_SERVER['PHP_SELF'] .
+      	        print "<a href='" . html_escape($_SERVER['PHP_SELF']) .
                       "?LETTER=$i' class='alpha'>$i</a>&nbsp; ";
             }
             print "</p>\n";

--- a/vexim/site.php
+++ b/vexim/site.php
@@ -37,7 +37,7 @@
         echo _('Search');
       ?>:
       <input type="text" size="20" name="searchfor"
-        value="<?php echo $_POST['searchfor']; ?>" class="textfield">
+        value="<?php echo html_escape($_POST['searchfor']); ?>" class="textfield">
       <input type="submit" name="search"
         value="<?php echo _('search'); ?>">
     </form>


### PR DESCRIPTION
The alphabetical filter links in `alpha_menu()` build their `href` from `$_SERVER['PHP_SELF']` without escaping, and `site.php` echoes the submitted search term straight back into the form. Both let injected markup run in the visitor's session.

`PHP_SELF` can carry attacker-controlled path info, e.g. a request to

    /adminuser.php/"><script>alert(document.cookie)</script>

makes every filter link on the page break out of the attribute. The domain search box in `site.php` has the same issue with the reflected POST value — `adminuser.php` already escapes its equivalent field, so this just brings `site.php` in line.

Wrapped both in the existing `html_escape()` helper, the same way `config/header.php` escapes the status messages it prints. No other changes.