### PR TITLE
Escape user-supplied fields when displaying account details

### DIFF
--- a/vexim/adminuser.php
+++ b/vexim/adminuser.php
@@ -96,28 +96,28 @@
             . $row['localpart']
             . '">';
           print '<img class="trash" title="Delete '
-            . $row['realname']
+            . html_escape($row['realname'])
             . '" src="images/trashcan.gif" alt="trashcan"></a></td>';
           print '<td><a href="adminuserchange.php?user_id=' . $row['user_id']
             . '&amp;localpart=' . $row['localpart']
             . '" title="' . _('Click to modify')
             . ' '
-            . $row['realname']
+            . html_escape($row['realname'])
             . '">'
-            . $row['realname']
+            . html_escape($row['realname'])
             . '</a></td>';
           print '<td><a href="adminuserchange.php?user_id=' . $row['user_id']
             . '&amp;localpart=' . $row['localpart']
             . '" title="' . _('Click to modify')
             . ' '
-            . $row['realname']
+            . html_escape($row['realname'])
             . '">'
             . $row['localpart'] .'@'. htmlspecialchars($_SESSION['domain'])
             . '</a></td>';
           print '<td class="check">';
           if ($row['admin'] == 1) {
             print  '<img class="check" src="images/check.gif" title="'
-            . $row['realname']
+            . html_escape($row['realname'])
             . _(' is an administrator')
             . '">';
           }

--- a/vexim/adminuserchange.php
+++ b/vexim/adminuserchange.php
@@ -54,7 +54,7 @@
           <td><?php echo _('Name'); ?>:</td>
           <td>
             <input type="text" size="25" name="realname"
-              value="<?php print $row['realname']; ?>" class="textfield" autofocus>
+              value="<?php print html_escape($row['realname']); ?>" class="textfield" autofocus>
             <input name="user_id" type="hidden"
               value="<?php print htmlspecialchars($_GET['user_id']); ?>">
           </td>
@@ -254,7 +254,7 @@
         <tr>
           <td><?php echo _('Vacation message'); ?>:</td>
           <td>
-            <textarea name="vacation" cols="40" rows="5" class="textfield"><?php print quoted_printable_decode($row['vacation'] ?? ''); ?></textarea>
+            <textarea name="vacation" cols="40" rows="5" class="textfield"><?php print html_escape(quoted_printable_decode($row['vacation'] ?? '')); ?></textarea>
           </td>
         </tr>
         <tr>
@@ -269,7 +269,7 @@
           <td valign="top"><?php echo _('Forward mail to'); ?>:</td>
           <td>
             <input type="text" size="25" name="forward" id="forward"
-            value="<?php print $row['forward']; ?>" class="textfield"><br>
+            value="<?php print html_escape($row['forward']); ?>" class="textfield"><br>
             <?php echo _('Enter full e-mail addresses, use commas to separate them'); ?>!<br>
             <?php echo _('or select from this list') .":<br>\n"; ?>
             <select name="forwardmenu" id="forwardmenu">
@@ -284,7 +284,7 @@
                 while ($rowuserlist = $sthuserlist->fetch()) {
               ?>
                 <option value="<?php echo $rowuserlist['username']; ?>">
-                  <?php echo $rowuserlist['realname']; ?>
+                  <?php echo html_escape($rowuserlist['realname']); ?>
                   (<?php echo $rowuserlist['username']; ?>)
                 </option>
               <?php
@@ -409,8 +409,8 @@
                     alt="trashcan">
                 </a>
               </td>
-              <td><?php echo $blockrow['blockhdr']; ?></td>
-              <td><?php echo $blockrow['blockval']; ?></td>
+              <td><?php echo html_escape($blockrow['blockhdr']); ?></td>
+              <td><?php echo html_escape($blockrow['blockval']); ?></td>
             </tr>
         <?php
           }

--- a/vexim/userchange.php
+++ b/vexim/userchange.php
@@ -33,7 +33,7 @@
     <div id="forms">
       <form name="userchange" method="post" action="userchangesubmit.php">
         <table align="center">
-	  <tr><td><?php echo _("Name"); ?>:</td><td><input name="realname" type="text" value="<?php print $row['realname']; ?>" class="textfield" autofocus></td></tr>
+	  <tr><td><?php echo _("Name"); ?>:</td><td><input name="realname" type="text" value="<?php print html_escape($row['realname']); ?>" class="textfield" autofocus></td></tr>
 	  <tr><td><?php echo _("Email Address"); ?>:</td><td><?php print $row['localpart']."@".htmlspecialchars($_SESSION['domain']); ?></td>
 	  <tr><td><?php echo _("Password"); ?>:</td><td><input name="clear" type="password" class="textfield"></td></tr>
 	  <tr><td class="padafter"><?php echo _("Verify Password"); ?>:</td><td><input name="vclear" type="password" class="textfield"></td></tr>
@@ -123,14 +123,14 @@
   	  </tr>
   	  <tr>
   	    <td><?php echo _('Vacation message'); ?>:</td>
-  	    <td><textarea name="vacation" cols="40" rows="5" class="textfield"><?php print quoted_printable_decode($row['vacation']); ?></textarea></td>
+  	    <td><textarea name="vacation" cols="40" rows="5" class="textfield"><?php print html_escape(quoted_printable_decode($row['vacation'])); ?></textarea></td>
   	  </tr>
   	  <tr><td><?php echo _("Forwarding enabled"); ?>:</td>
   	    <td><input name="on_forward" type="checkbox" id="on_forward"
           <?php if($row['on_forward'] == "1") { print " checked "; } ?>>
           </td></tr>
   	  <tr><td><?php echo _("Forward mail to");?>:</td>
-	    <td><input type="text" name="forward" id="forward" value="<?php print $row['forward']; ?>" class="textfield"><br>
+	    <td><input type="text" name="forward" id="forward" value="<?php print html_escape($row['forward']); ?>" class="textfield"><br>
           <?php echo _("Enter full e-mail addresses, use commas to separate them."); ?>
         </td></tr>
   	  <tr><td><?php echo  _("Store Forwarded Mail Locally");?>:</td>
@@ -162,7 +162,7 @@
       <?php if ($blocksuccess) {
 	while ($blockrow = $blocksth->fetch()) {
 	  print "<tr><td><a href=\"userblocksubmit.php?action=delete&block_id={$blockrow['block_id']}\"><img border=\"0\" width=\"10\" height=\"16\" title=\"Delete\" src=\"images/trashcan.gif\" alt=\"trashcan\"></a></td>";
-	  print "<td>{$blockrow['blockhdr']}</td><td>{$blockrow['blockval']}</td></tr>\n";
+	  print "<td>" . html_escape($blockrow['blockhdr']) . "</td><td>" . html_escape($blockrow['blockval']) . "</td></tr>\n";
 	}
       }
 	?>


### PR DESCRIPTION
A mailbox user can freely set their real name, vacation message, forward address and header-blocking filters. These values are printed into the account pages without escaping, so stored markup runs when the page is rendered.

The case that matters is the admin views: a normal user can put e.g.

    <script>...</script>

in their real name or vacation message, and it then executes in the domain admin's session when the admin lists users in `adminuser.php` or opens one in `adminuserchange.php`.

Wrapped the affected fields in the existing `html_escape()` helper across `userchange.php`, `adminuserchange.php` and `adminuser.php`. Values that are already escaped, constant, or charset-restricted (localpart/domain) are left alone to keep the diff minimal.