### PR TITLE
Fix domain capability checks on the user edit form

### DIFF
--- a/vexim/adminuserchangesubmit.php
+++ b/vexim/adminuserchangesubmit.php
@@ -84,18 +84,18 @@
     }
   }
   # Do some checking, to make sure the user is ALLOWED to make these changes
-  if ((isset($_POST['on_piped'])) && ($row['pipe'] = 1)) {
+  if ((isset($_POST['on_piped'])) && ($row['pipe'] == 1)) {
     $_POST['on_piped'] = 1;
   } else {
     $_POST['on_piped'] = 0;
   }
-  if ((isset($_POST['on_avscan'])) && ($row['avscan'] = 1)) {
+  if ((isset($_POST['on_avscan'])) && ($row['avscan'] == 1)) {
     $_POST['on_avscan'] = 1;
   } else {
     $_POST['on_avscan'] = 0;
   }
 
-  if ((isset($_POST['on_spamassassin'])) && ($row['spamassassin'] = 1)) {
+  if ((isset($_POST['on_spamassassin'])) && ($row['spamassassin'] == 1)) {
     $_POST['on_spamassassin'] = 1;
   } else {
     $_POST['on_spamassassin'] = 0;


### PR DESCRIPTION
The checks in adminuserchangesubmit.php that decide whether on_piped,
on_avscan and on_spamassassin may be enabled use a single `=`, so they
assign 1 to $row[...] and the condition is always true. The add form
(adminuseraddsubmit.php) uses `==` and behaves as intended.

on_piped is the main issue: a piped user's smtp value is used directly
as the pipe_transport command in the virtual_domains router, so while
the check is broken a domain admin can switch a user to piped delivery
even when the domain doesn't have pipe enabled. on_avscan and
on_spamassassin are less of an issue because the routers also check the
domain flag, but they have the same typo.

Changes the three comparisons to ==.
