### PR TITLE
Stop vacation autoreplies from looping on automated mail

### DIFF
--- a/docs/debian-conf.d/router/250_vexim_virtual_domains
+++ b/docs/debian-conf.d/router/250_vexim_virtual_domains
@@ -6,6 +6,7 @@ virtual_vacation:
   driver = accept
   domains = +local_domains
   condition = ${if and { {!match {$h_precedence:}{(?i)junk|bulk|list}} \
+                         {!match {$h_auto-submitted:}{(?i)auto-}} \
                          {eq {${lookup mysql{select users.on_vacation from users,domains \
                                 where localpart = '${quote_mysql:$local_part}' \
                                 and domain = '${quote_mysql:$domain}' \

--- a/docs/debian-conf.d/transport/30_vexim_virtual_vacation_delivery
+++ b/docs/debian-conf.d/transport/30_vexim_virtual_vacation_delivery
@@ -7,7 +7,7 @@ virtual_vacation_delivery:
   from     = "${local_part}@${domain}"
   to       = ${sender_address}
   subject  = "Autoreply from ${local_part}@${domain}"
-  headers  = "Content-Type: text/plain; charset=UTF-8\nContent-Transfer-Encoding: quoted-printable"
+  headers  = "Content-Type: text/plain; charset=UTF-8\nContent-Transfer-Encoding: quoted-printable\nAuto-Submitted: auto-replied"
   text     = ${lookup mysql{select vacation from users,domains \
                 where domain='${quote_mysql:$domain}' \
                 and localpart='${quote_mysql:$local_part}' \


### PR DESCRIPTION
The vacation autoresponder replies to anything that isn't flagged with Precedence: junk/bulk/list. It doesn't look at Auto-Submitted, and the autoreply itself doesn't set that header, so two accounts that are both on vacation keep replying to each other, and replies also go out to other automated senders.

Set Auto-Submitted: auto-replied on the autoreply, and skip incoming mail that already carries an Auto-Submitted header. That breaks the account-to-account loop and avoids answering automated mail, while still replying to normal messages.

This doesn't add once/once_repeat rate limiting, which needs a writable state file and is specific to each install.