### PR TITLE
Reject control characters in the localpart

### DIFF
--- a/vexim/adminuseraddsubmit.php
+++ b/vexim/adminuseraddsubmit.php
@@ -102,6 +102,7 @@
   }
 
   if (preg_match("/['@%!\/\| ']/",$_POST['localpart'])
+    || preg_match("/[[:cntrl:]]/",$_POST['localpart'])
     || preg_match("/^\s*$/",$_POST['localpart'])) {
     header("Location: adminuser.php?badname={$_POST['localpart']}");
     die;


### PR DESCRIPTION
The localpart check blocks a set of punctuation but not control characters, so a value with an embedded newline passes validation and is then used in the To header of the welcome mail (and stored as the username). Reject control characters too; a localpart never legitimately contains them.