### PR TITLE
Enforce the pipe capability in Exim, not just in the web UI

### DIFF
--- a/docs/debian-conf.d/router/250_vexim_virtual_domains
+++ b/docs/debian-conf.d/router/250_vexim_virtual_domains
@@ -38,6 +38,25 @@ virtual_forward:
                                 and users.on_forward = '1' \
                                 and users.domain_id=domains.domain_id}}}{1} }} {yes}{no} }
 
+virtual_piped:
+  driver = redirect
+  domains = +local_domains
+  allow_fail
+  data = ${lookup mysql{select smtp from users,domains \
+        where localpart = '${quote_mysql:$local_part}' \
+        and domain = '${quote_mysql:$domain}' \
+        and users.on_piped = '1' \
+        and domains.pipe = '1' \
+        and domains.enabled = '1' \
+        and users.enabled = '1' \
+        and users.domain_id = domains.domain_id}}
+  .ifdef VEXIM_LOCALPART_SUFFIX
+    local_part_suffix = VEXIM_LOCALPART_SUFFIX
+    local_part_suffix_optional
+  .endif
+  retry_use_local_part
+  pipe_transport = address_pipe
+
 virtual_domains:
   driver = redirect
   domains = +local_domains
@@ -67,7 +86,10 @@ virtual_domains:
   retry_use_local_part
   file_transport = virtual_delivery
   reply_transport = address_reply
-  pipe_transport = address_pipe
+  # Piped delivery is handled by the virtual_piped router, which checks that
+  # the user is on_piped and the domain allows pipe. Refuse pipes here so a
+  # stray "|command" in the smtp field can never be executed by this router.
+  forbid_pipe
 
 # A group is a list of users
 #


### PR DESCRIPTION
Whether a delivery is piped is currently decided solely by whether the stored smtp field begins with "|"; the routers never check on_piped or the domain's pipe flag. on_avscan and on_spamassassin are already re-checked against the domain in the routers, so pipe is the odd one out.

Add a virtual_piped router that only pipes when the user is on_piped and the domain has pipe enabled, and set forbid_pipe on virtual_domains so a stray "|command" smtp value can't be executed there. Piped users keep working; for everyone else a pipe can no longer be reached.

The catchall and group routers also set a pipe transport, but their data comes from a validated forward address / the group member list rather than the raw smtp field, so they are left unchanged.

I haven't been able to test this against a live Exim setup, so please sanity-check the new router before relying on it.