### PR TITLE
Harden the session cookie and regenerate the session id on login

### DIFF
--- a/vexim/config/httpheaders.php
+++ b/vexim/config/httpheaders.php
@@ -1,6 +1,18 @@
 <?php
+  // Harden the session cookie before the session starts: not readable from
+  // JavaScript, flagged Secure on HTTPS requests, and not sent on cross-site
+  // requests (a basic CSRF mitigation).
+  session_set_cookie_params([
+    'lifetime' => 0,
+    'path'     => '/',
+    'httponly' => true,
+    'samesite' => 'Strict',
+    'secure'   => (!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off'),
+  ]);
   session_start();
   header("Cache-control: private"); // IE6 hack to back forms + BACK button work
   header("Content-Type: text/html; charset=utf-8");
+  header("X-Content-Type-Options: nosniff");
+  header("X-Frame-Options: SAMEORIGIN");
   if (isset($CSPenabled) && $CSPenabled === true)  header("Content-Security-Policy: default-src 'self';");
 ?>

--- a/vexim/login.php
+++ b/vexim/login.php
@@ -60,6 +60,9 @@
     }
   }
 
+  # the credentials check out, so rotate the session id to prevent session fixation
+  session_regenerate_id(true);
+
   # populate session variables from what was retrieved from the database (NOT what they posted)
   $_SESSION['username'] = $row['username'];
   $_SESSION['localpart'] = $row['localpart'];


### PR DESCRIPTION
The session cookie is created with PHP's defaults (no HttpOnly, Secure or SameSite) and the session id isn't rotated on login.

Set the cookie params before session_start() so the cookie is HttpOnly, SameSite=Strict and Secure on HTTPS requests, and call session_regenerate_id(true) once the password check passes to prevent session fixation. Also send X-Content-Type-Options and X-Frame-Options.

Secure is only set when the request itself is HTTPS, so plain-HTTP and proxied setups keep working. With SameSite=Strict, following an external link into the panel won't send the session cookie on that first request (you'd see the login page until you navigate within the site once) — fine for an admin tool, and it also blocks the GET-based CSRF vectors.

The array form of session_set_cookie_params() used here requires PHP 7.3+, which the project already targets.