### PR TITLE
Scope the block-filter delete to the logged-in user

### DIFF
--- a/vexim/userblocksubmit.php
+++ b/vexim/userblocksubmit.php
@@ -5,9 +5,9 @@
   include_once dirname(__FILE__) . "/config/httpheaders.php";
 
   if ($_GET['action'] == "delete") {
-    $query = "DELETE FROM blocklists WHERE block_id=:block_id";
+    $query = "DELETE FROM blocklists WHERE block_id=:block_id AND user_id=:user_id";
     $sth = $dbh->prepare($query);
-    $success = $sth->execute(array(':block_id'=>$_GET['block_id']));
+    $success = $sth->execute(array(':block_id'=>$_GET['block_id'], ':user_id'=>$_SESSION['user_id']));
     if ($success) {
       header ("Location: userchange.php?updated");
     } else {


### PR DESCRIPTION
userblocksubmit.php deletes a blocklists row by block_id with no ownership check, so any logged-in user could delete another user's header-blocking filter by passing an arbitrary block_id. The insert just below already scopes to the session user, and adminuserblocksubmit.php scopes its delete too.

Add user_id and domain_id from the session to the DELETE's WHERE clause.