### PR TITLE
Add CSRF protection to the web interface

### DIFF
--- a/vexim/adminaliasadd.php
+++ b/vexim/adminaliasadd.php
@@ -24,6 +24,7 @@
     </div>
     <div id="Forms">
       <form name="adminadd" method="post" action="adminaliasaddsubmit.php">
+        <?php echo csrf_input(); ?>
         <table align="center">
           <tr>
             <td><?php echo _('Alias Name'); ?>:</td>

--- a/vexim/adminaliaschange.php
+++ b/vexim/adminaliaschange.php
@@ -45,6 +45,7 @@
 		}else{
 	?>
 	<form name="aliaschange" method="post" action="adminaliaschangesubmit.php">
+	  <?php echo csrf_input(); ?>
         <table align="center">
           <tr>
             <td><?php echo _('Alias Name'); ?>:</td>

--- a/vexim/adminaliasdelete.php
+++ b/vexim/adminaliasdelete.php
@@ -6,6 +6,7 @@
 
   if(array_key_exists('confirm', $_GET)) {
     if ($_GET['confirm'] == '1') {
+      csrf_verify();
       $query = "DELETE FROM users
         WHERE user_id=:user_id
         AND domain_id=:domain_id
@@ -40,6 +41,7 @@
     </div>
     <div id="Content">
       <form name="aliasdelete" method="get" action="adminaliasdelete.php">
+        <?php echo csrf_input(); ?>
         <table align="center">
           <tr>
             <td colspan="2">

--- a/vexim/admincatchall.php
+++ b/vexim/admincatchall.php
@@ -34,6 +34,7 @@
 		}else{
 	?>
 	<form name="admincatchall" method="post" action="admincatchallsubmit.php">
+	  <?php echo csrf_input(); ?>
         <table align="center">
           <tr>
             <td><?php echo _('Alias Name'); ?>:</td>

--- a/vexim/admincatchalladd.php
+++ b/vexim/admincatchalladd.php
@@ -20,6 +20,7 @@
     </div>
     <div id="Forms">
       <form name="admincatchall" method="post" action="admincatchallsubmit.php">
+        <?php echo csrf_input(); ?>
         <table align="center">
           <tr>
             <td><?php echo _('Alias Name'); ?>:</td>

--- a/vexim/adminfailadd.php
+++ b/vexim/adminfailadd.php
@@ -19,6 +19,7 @@
     </div>
     <div id="Forms">
       <form name="adminadd" method="post" action="adminfailaddsubmit.php">
+        <?php echo csrf_input(); ?>
         <table align="center">
           <tr>
             <td><?php echo _('Fail Name'); ?>:</td>

--- a/vexim/adminfailchange.php
+++ b/vexim/adminfailchange.php
@@ -35,6 +35,7 @@
 		}else{
 	?>
       <form name="failchange" method="post" action="adminfailchangesubmit.php">
+        <?php echo csrf_input(); ?>
 	<table align="center">
       <tr>
         <td><?php echo _('Fail name'); ?>:</td>

--- a/vexim/admingroupadd.php
+++ b/vexim/admingroupadd.php
@@ -18,6 +18,7 @@
     </div>
     <div id="Forms">
     <form name="adminadd" method="post" action="admingroupaddsubmit.php">
+      <?php echo csrf_input(); ?>
       <table align="center">
         <tr>
           <td><?php echo _('Group Address'); ; ?>:</td>

--- a/vexim/admingroupchange.php
+++ b/vexim/admingroupchange.php
@@ -38,6 +38,7 @@
       <table align="center">
         <form name="groupchange" method="post"
           action="admingroupchangesubmit.php">
+        <?php echo csrf_input(); ?>
         <tr>
           <td><?php echo _('Group Address'); ?>:</td>
           <td>
@@ -134,6 +135,7 @@
           </tr>
           <form method="post" action="admingroupcontentaddsubmit.php"
             name="groupcontentadd">
+          <?php echo csrf_input(); ?>
           <tr>
             <td><?php echo _('Add Member'); ?></td>
             <td>

--- a/vexim/admingroupdelete.php
+++ b/vexim/admingroupdelete.php
@@ -5,6 +5,7 @@
 
   if(array_key_exists('confirm', $_GET)) {
     if ($_GET['confirm'] == '1') {
+      csrf_verify();
       # confirm that the user is deleting a group they are permitted to change before going further
 	  $query = "SELECT * FROM groups WHERE id=:group_id AND domain_id=:domain_id";
       $sth = $dbh->prepare($query);
@@ -55,6 +56,7 @@
     </div>
     <div id="Content">
       <form name="groupdelete" method="get" action="admingroupdelete.php">
+        <?php echo csrf_input(); ?>
         <table align="center">
           <tr>
             <td colspan="2">

--- a/vexim/adminlists.php
+++ b/vexim/adminlists.php
@@ -22,6 +22,7 @@
     </div>
     <div id="Forms">
       <form name="adminlists" method="post" action="adminlists.php">
+        <?php echo csrf_input(); ?>
 	<table align="center">
 	  <tr>
             <td>

--- a/vexim/adminuser.php
+++ b/vexim/adminuser.php
@@ -51,6 +51,7 @@
         alpha_menu($alphausers)
       ?>
       <form name="search" method="post" action="adminuser.php">
+        <?php echo csrf_input(); ?>
         <?php echo _('Search'); ?>:
         <input type="text" size="20" name="searchfor"
           value="<?php echo htmlspecialchars($_POST['searchfor']); ?>" class="textfield">

--- a/vexim/adminuseradd.php
+++ b/vexim/adminuseradd.php
@@ -42,6 +42,7 @@
     </div>
     <div id="forms">
     <form name="adminadd" method="post" action="adminuseraddsubmit.php">
+      <?php echo csrf_input(); ?>
       <table align="center">
         <tr>
           <td><?php echo _('Name'); ?>:</td>

--- a/vexim/adminuserblocksubmit.php
+++ b/vexim/adminuserblocksubmit.php
@@ -7,6 +7,7 @@
 
   $action = (isset($_GET['action']) ? $_GET['action'] : null);
   if ($action == 'delete') {
+    csrf_verify();
     $query = "DELETE FROM blocklists WHERE block_id=:block_id
 			AND domain_id=:domain_id AND user_id=:user_id";
     $sth = $dbh->prepare($query);

--- a/vexim/adminuserchange.php
+++ b/vexim/adminuserchange.php
@@ -49,6 +49,7 @@
 	?>
 	
     <form name="userchange" method="post" action="adminuserchangesubmit.php">
+      <?php echo csrf_input(); ?>
       <table align="center">
         <tr>
           <td><?php echo _('Name'); ?>:</td>
@@ -350,6 +351,7 @@
     </form>
     <br>
     <form name="blocklist" method="post" action="adminuserblocksubmit.php">
+      <?php echo csrf_input(); ?>
       <table align="center">
         <tr>
           <td colspan="2">
@@ -404,7 +406,7 @@
 					. '&block_id='
 					. $blockrow['block_id']
 					.'&localpart='
-					. htmlspecialchars($_GET['localpart']);?>">
+					. htmlspecialchars($_GET['localpart']) . '&csrf_token=' . csrf_token();?>">
                   <img class="trash" title="Delete" src="images/trashcan.gif"
                     alt="trashcan">
                 </a>

--- a/vexim/adminuserdelete.php
+++ b/vexim/adminuserdelete.php
@@ -17,6 +17,7 @@ if (!$sth->rowCount()) {
 if(!isset($_GET['confirm'])) { $_GET['confirm'] = null; }
 
 if ($_GET['confirm'] == '1') {
+  csrf_verify();
   # prevent deleting the last admin
   $query = "SELECT COUNT(user_id) AS count FROM users
     WHERE admin=1 AND domain_id=:domain_id
@@ -81,6 +82,7 @@ if ($_GET['confirm'] == '1') {
     </div>
     <div id="Content">
       <form name="userdelete" method="get" action="adminuserdelete.php">
+        <?php echo csrf_input(); ?>
         <table align="center">
           <tr>
             <td colspan="2">

--- a/vexim/config/csrf.php
+++ b/vexim/config/csrf.php
@@ -1,0 +1,40 @@
+<?php
+  /*
+    Cross-site request forgery protection.
+
+    A random token is stored in the session and must accompany every
+    state-changing request. httpheaders.php verifies it on every POST;
+    the few delete actions that use GET call csrf_verify() directly.
+    Forms include the token with csrf_input().
+
+    This file has no dependencies beyond core PHP so it can be included
+    early (from httpheaders.php) without worrying about include order.
+  */
+
+  // Return the session's CSRF token, creating it on first use.
+  function csrf_token()
+  {
+    if (empty($_SESSION['csrf_token'])) {
+      $_SESSION['csrf_token'] = bin2hex(random_bytes(32));
+    }
+    return $_SESSION['csrf_token'];
+  }
+
+  // A hidden field carrying the token. Place inside every state-changing form.
+  function csrf_input()
+  {
+    // The token is hex (bin2hex), so it needs no HTML escaping.
+    return '<input type="hidden" name="csrf_token" value="' . csrf_token() . '">';
+  }
+
+  // Abort the request unless it carries the correct token.
+  function csrf_verify()
+  {
+    $sent = isset($_POST['csrf_token']) ? $_POST['csrf_token']
+          : (isset($_GET['csrf_token']) ? $_GET['csrf_token'] : '');
+    if (empty($_SESSION['csrf_token']) || !is_string($sent)
+        || !hash_equals($_SESSION['csrf_token'], $sent)) {
+      http_response_code(403);
+      die('Invalid or missing CSRF token. Please reload the form and try again.');
+    }
+  }

--- a/vexim/config/httpheaders.php
+++ b/vexim/config/httpheaders.php
@@ -1,5 +1,11 @@
 <?php
   session_start();
+  require_once dirname(__FILE__) . '/csrf.php';
+  # Reject any state-changing POST that does not carry a valid CSRF token.
+  # GET delete actions call csrf_verify() themselves (see csrf.php).
+  if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    csrf_verify();
+  }
   header("Cache-control: private"); // IE6 hack to back forms + BACK button work
   header("Content-Type: text/html; charset=utf-8");
   if (isset($CSPenabled) && $CSPenabled === true)  header("Content-Security-Policy: default-src 'self';");

--- a/vexim/index.php
+++ b/vexim/index.php
@@ -16,6 +16,7 @@
     <?php include dirname(__FILE__) . '/config/header.php'; ?>
     <div id="Centered">
       <form class="login" name="login" method="post" action="login.php">
+        <?php echo csrf_input(); ?>
         <table align="center">
           <tr>
             <td><?php echo _('Username'); ?>:</td>

--- a/vexim/site.php
+++ b/vexim/site.php
@@ -33,6 +33,7 @@
       alpha_menu($alphadomains);
     ?>
     <form name="search" method="post" action="site.php">
+      <?php echo csrf_input(); ?>
       <?php
         echo _('Search');
       ?>:

--- a/vexim/siteadd.php
+++ b/vexim/siteadd.php
@@ -20,6 +20,7 @@
     </div>
     <div id="forms">
       <form name="siteadd" method="post" action="siteaddsubmit.php">
+        <?php echo csrf_input(); ?>
         <table align="center">
           <tr>
             <td><?php echo _('New Domain'); ?>:</td>

--- a/vexim/sitechange.php
+++ b/vexim/sitechange.php
@@ -20,6 +20,7 @@ include_once dirname(__FILE__) . "/config/httpheaders.php";
 </div>
 <div id="Forms">
     <form name="passwordchange" method="post" action="sitechangesubmit.php">
+      <?php echo csrf_input(); ?>
         <table align="center">
             <tr>
                 <td colspan="2"><h4><?php echo _("Modify Domain Admin"); ?>:</h4></td>
@@ -68,6 +69,7 @@ include_once dirname(__FILE__) . "/config/httpheaders.php";
         </table>
     </form><br>
     <form name="domainchange" method="post" action="sitechangesubmit.php">
+      <?php echo csrf_input(); ?>
         <table align="center">
             <tr>
                 <td colspan="2"><h4><?php echo _("Modify Domain Properties"); ?>:</h4></td>
@@ -128,6 +130,7 @@ include_once dirname(__FILE__) . "/config/httpheaders.php";
         </table>
     </form><br>
     <form name="allusers" method="post" action="sitechangesubmit.php">
+      <?php echo csrf_input(); ?>
             <input name="allusers" type="hidden" value="<?php print htmlspecialchars($_GET['domain_id']); ?>">
             <input name="domain_id" type="hidden" value="<?php print htmlspecialchars($_GET['domain_id']); ?>">
             <input name="domain" type="hidden" value="<?php print htmlspecialchars($_GET['domain']); ?>">

--- a/vexim/sitedelete.php
+++ b/vexim/sitedelete.php
@@ -86,6 +86,7 @@
     </div>
     <div id='Content'>
       <form name='domaindelete' method='post' action='sitedelete.php'>
+        <?php echo csrf_input(); ?>
 	<table align="center">
 	  <tr><td colspan='2'><?php printf (_("Please confirm deleting domain %s."), htmlspecialchars($_GET['domain'])); ?>:</td></tr>
 	  <?php if (($_GET['type'] != "relay") && ($_GET['type'] != "alias")) {

--- a/vexim/sitepassword.php
+++ b/vexim/sitepassword.php
@@ -19,6 +19,7 @@
   </div>
   <div id="forms">
       <form name="sitepassword" method="post" action="sitepasswordsubmit.php">
+        <?php echo csrf_input(); ?>
 	<table align="center">
 		<tr><td colspan="2" class="padafter"><?php echo _("Change SiteAdmin Password"); ?>:</td></tr>
 		<tr><td><?php echo _("Password"); ?>:</td><td><input type="password" size="25" name="clear" autofocus></td></tr>

--- a/vexim/userblocksubmit.php
+++ b/vexim/userblocksubmit.php
@@ -5,6 +5,7 @@
   include_once dirname(__FILE__) . "/config/httpheaders.php";
 
   if ($_GET['action'] == "delete") {
+    csrf_verify();
     $query = "DELETE FROM blocklists WHERE block_id=:block_id AND user_id=:user_id";
     $sth = $dbh->prepare($query);
     $success = $sth->execute(array(':block_id'=>$_GET['block_id'], ':user_id'=>$_SESSION['user_id']));

--- a/vexim/userchange.php
+++ b/vexim/userchange.php
@@ -32,6 +32,7 @@
     </div>
     <div id="forms">
       <form name="userchange" method="post" action="userchangesubmit.php">
+        <?php echo csrf_input(); ?>
         <table align="center">
 	  <tr><td><?php echo _("Name"); ?>:</td><td><input name="realname" type="text" value="<?php print html_escape($row['realname']); ?>" class="textfield" autofocus></td></tr>
 	  <tr><td><?php echo _("Email Address"); ?>:</td><td><?php print $row['localpart']."@".htmlspecialchars($_SESSION['domain']); ?></td>
@@ -42,6 +43,7 @@
         </table>
       </form>
       <form name="userchange" method="post" action="userchangesubmit.php">
+        <?php echo csrf_input(); ?>
         <table align="center">
          <?php if($row['type']!="alias") { ?>
 	  <tr><td colspan="2"><?php
@@ -144,6 +146,7 @@
   </form>
 <?php if ($row['type']!="alias") { ?>
   <form name="blocklist" method="post" action="userblocksubmit.php">
+    <?php echo csrf_input(); ?>
     <table align="center">
   	  <tr><td><?php echo _("Add a new header blocking filter"); ?>:</td></tr>
   	  <tr><td><select name="blockhdr" class="textfield">
@@ -161,7 +164,7 @@
   	  <tr><th><?php echo _("Delete"); ?></th><th><?php echo _("Blocked Header"); ?></th><th><?php echo _("Content"); ?></th></tr>
       <?php if ($blocksuccess) {
 	while ($blockrow = $blocksth->fetch()) {
-	  print "<tr><td><a href=\"userblocksubmit.php?action=delete&block_id={$blockrow['block_id']}\"><img border=\"0\" width=\"10\" height=\"16\" title=\"Delete\" src=\"images/trashcan.gif\" alt=\"trashcan\"></a></td>";
+	  print "<tr><td><a href=\"userblocksubmit.php?action=delete&block_id={$blockrow['block_id']}&csrf_token=" . csrf_token() . "\"><img border=\"0\" width=\"10\" height=\"16\" title=\"Delete\" src=\"images/trashcan.gif\" alt=\"trashcan\"></a></td>";
 	  print "<td>" . html_escape($blockrow['blockhdr']) . "</td><td>" . html_escape($blockrow['blockval']) . "</td></tr>\n";
 	}
       }


### PR DESCRIPTION
Add a per-session CSRF token that must accompany every state-changing request.

config/csrf.php holds the whole mechanism: csrf_token() creates/returns the token, csrf_input() renders the hidden form field, and csrf_verify() checks it. It depends only on core PHP so httpheaders.php can include it early.

httpheaders.php verifies the token on every POST in one place, so all the POST handlers are covered without changing them. The delete actions that use GET (user/alias/group delete and the block-filter delete) call csrf_verify() directly and carry the token in their link/form. Every form includes the token with csrf_input().

The API endpoint (api/change-user-password.php) is intentionally not covered: it has no session, authenticates with the current password, and is called by external clients.

Heads-up on overlap with #301: both change httpheaders.php right after session_start(), so whichever of the two is merged second will need a small rebase there. There's no behavioural conflict — session_regenerate_id() in #301 keeps the session token.