### PR TITLE
Storing DKIM information in the database

### DIFF
--- a/docs/debian-conf.d/main/00_vexim_listmacrosdefs
+++ b/docs/debian-conf.d/main/00_vexim_listmacrosdefs
@@ -37,6 +37,19 @@ keep_environment =
 add_environment = MAIN_ADD_ENVIRONMENT
 .endif
 
+# DKIM
+# Requires dkim.sql migration to be run
+DKIM_DOMAIN = ${lc:${domain:$h_from:}}
+DKIM_SELECTOR = ${lookup mysql {SELECT d.selector FROM dkim d JOIN domains dom ON d.domain_id = dom.domain_id WHERE dom.domain = '${quote_mysql:DKIM_DOMAIN}' AND d.enabled = 1}{$value}fail}
+DKIM_PRIVATE_KEY = ${lookup mysql {SELECT d.private_key FROM dkim d JOIN domains dom ON d.domain_id = dom.domain_id WHERE dom.domain = '${quote_mysql:DKIM_DOMAIN}' AND d.enabled = 1}{$value}fail}
+DKIM_CANON = relaxed
+DKIM_STRICT = 0
+DKIM_TIMESTAMPS = 0
+
+# Disable DKIM verification for incoming mail (since we don't want to verify inbound)
+DKIM_VERIFY_DOMAIN = ${if match_domain{$sender_address_domain}{+local_domains}{0}{1}}
+
+
 # validation of sending mailserver
 #CHECK_RCPT_REVERSE_DNS = true
 #CHECK_RCPT_SPF = true

--- a/docs/dkim/dkim.sql
+++ b/docs/dkim/dkim.sql
@@ -1,0 +1,15 @@
+CREATE TABLE `dkim` (
+    `dkim_id`       INT(10) UNSIGNED NOT NULL AUTO_INCREMENT,
+    `domain_id`     INT(10) UNSIGNED NOT NULL,
+    `selector`      VARCHAR(63) NOT NULL DEFAULT 'default',
+    `private_key`   TEXT NOT NULL,
+    `public_key`    TEXT NOT NULL,
+    `canonical`     ENUM('simple', 'relaxed') NOT NULL DEFAULT 'relaxed',
+    `sign_headers`  VARCHAR(255) DEFAULT NULL,  -- Optional: custom headers to sign
+    `enabled`       TINYINT(1) NOT NULL DEFAULT 1,
+    `created_at`    TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    `updated_at`    TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    PRIMARY KEY (`dkim_id`),
+    UNIQUE KEY `domain_selector` (`domain_id`, `selector`),
+    FOREIGN KEY (`domain_id`) REFERENCES `domains` (`domain_id`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;


### PR DESCRIPTION
DKIM keys stored in the vexim database, been running this for years (been a couple of sql updates over the years). Forgot to update the issue I posted almost 10 years ago about it.

Left dkim_sign_headers up to Exims standard signing because despite many hours of testing, could never get a stable dkim result with it.. Exims built in has worked fine for it (it's a busy mailserver).

The SQL is basic but leaves in the option to add sign_headers if you so want.

Cf #97 