### PR TITLE
Remote smtp interface (rewrite of #245)

### DIFF
--- a/docs/debian-conf.d/main/00_vexim_listmacrosdefs
+++ b/docs/debian-conf.d/main/00_vexim_listmacrosdefs
@@ -91,3 +91,12 @@ CHECK_DATA_LOCAL_ACL_FILE = /etc/exim4/vexim-acl-check-content.conf
 # compact version of the report. If you tweak your template this way, you may
 # as well want to change the header name here.
 VEXIM_SPAM_REPORT_HEADER_NAME = X-Spam-Report
+
+# Set the IP which should be used for outgoing connections
+# This feature makes it easy to use different IPs per domain.
+VEXIM_OUTIP = SELECT DISTINCT out_ip FROM domains \
+                           WHERE domain = '${quote_mysql:$sender_address_domain}' \
+                               AND out_ip <> TRIM('')
+# set IPs of the outgoing interface as default/fallback. This value should be changed!
+OUTGOING_IP_DEFAULT = :: ; 127.0.0.1
+REMOTE_SMTP_INTERFACE = ${lookup mysql{VEXIM_OUTIP}{ <; $value }{ <; OUTGOING_IP_DEFAULT }}

--- a/setup/mysql.sql
+++ b/setup/mysql.sql
@@ -54,6 +54,7 @@ CREATE TABLE `domains` (
   `spamassassin` tinyint(1) NOT NULL DEFAULT '0',
   `sa_tag` smallint(5) unsigned NOT NULL DEFAULT '0',
   `sa_refuse` smallint(5) unsigned NOT NULL DEFAULT '0',
+  `out_ip` varchar(255) NOT NULL DEFAULT '',
   PRIMARY KEY (`domain_id`),
   UNIQUE KEY `domain` (`domain`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 ROW_FORMAT=DYNAMIC;

--- a/setup/pgsql.sql
+++ b/setup/pgsql.sql
@@ -61,7 +61,8 @@ CREATE TABLE "domains" (
   "pipe" smallint NOT NULL default '0' CHECK("pipe" BETWEEN 0 AND 1),
   "spamassassin" smallint NOT NULL default '0' CHECK("spamassassin" BETWEEN 0 AND 1),
   "sa_tag" int NOT NULL default '0' CHECK("sa_tag" > -1),
-  "sa_refuse" int NOT NULL default '0' CHECK("sa_refuse" > -1));
+  "sa_refuse" int NOT NULL default '0' CHECK("sa_refuse" > -1)),
+  "out_ip" varchar(255) NOT NULL default '';
 ALTER TABLE "domains" OWNER TO vexim;
 
 --


### PR DESCRIPTION
This is a rewrite of PR #245 as Exim has incorporated the functionality and some of the old PR is obsolete.

This is only the change in the exim config to read the outgoing IPs for a domain from the database and an update to the database create scripts.

Changes for the PHP-UI should be done in a separate PR. It's just to add one field to the domain form.
Veximpy does already use the out_ip field.
The field should contain a semicolon separated list of IPs (IPv6 and IPv4 is allowed). Veximpy runs some checks on the IPs before accepting it.

Usage is in Debian split config in transport/30_exim4-config_remote_smtp:

.ifdef REMOTE_SMTP_INTERFACE
  interface = REMOTE_SMTP_INTERFACE
.endif

I did exclude my monitoring script which was included in PR #245.  Reviewing should be easier now.

It is tested for years on my live server.