### PR TITLE
Remove pipe users, add lmtp, bugfixes

### DIFF
--- a/docs/debian-conf.d/main/00_vexim_listmacrosdefs
+++ b/docs/debian-conf.d/main/00_vexim_listmacrosdefs
@@ -90,7 +90,7 @@ i# lmtp delivery to an lmtp capable application like dovecot
 # this will enable the LMTP routers and set a command or socket in the LMTP transport
 # ! Set only one of the macros !
 #LMTP_COMMAND = /some/local/lmtp/delivery/program
-LMTP_SOCKET = /var/run/dovecot/lmtp
+#LMTP_SOCKET = /var/run/dovecot/lmtp
 
 # Exim will put the detailed spam report into an X-Spam-Report header by default.
 # This report is really huge by default, but its template can be tweaked to make

--- a/docs/debian-conf.d/main/00_vexim_listmacrosdefs
+++ b/docs/debian-conf.d/main/00_vexim_listmacrosdefs
@@ -83,6 +83,14 @@ VEXIM_LOCALPART_SUFFIX = +*
 
 CHECK_RCPT_LOCAL_ACL_FILE = /etc/exim4/vexim-acl-check-rcpt.conf
 CHECK_DATA_LOCAL_ACL_FILE = /etc/exim4/vexim-acl-check-content.conf
+CHECK_MIME_LOCAL_ACL_FILE = /etc/exim4/vexim-acl-check-mime.conf
+
+i# lmtp delivery to an lmtp capable application like dovecot
+# can be enabled by setting either LMTP_COMMAND or LMTP_SOCKET
+# this will enable the LMTP routers and set a command or socket in the LMTP transport
+# ! Set only one of the macros !
+#LMTP_COMMAND = /some/local/lmtp/delivery/program
+LMTP_SOCKET = /var/run/dovecot/lmtp
 
 # Exim will put the detailed spam report into an X-Spam-Report header by default.
 # This report is really huge by default, but its template can be tweaked to make

--- a/docs/debian-conf.d/router/250_vexim_virtual_domains
+++ b/docs/debian-conf.d/router/250_vexim_virtual_domains
@@ -1,12 +1,13 @@
-
 ### router/250_vexim_virtual_domains
+###
+### to enable routing for LMTP transport
+### set one of LMTP_COMMAND or LMTP_SOCKET in main/00_vexim_listmacrosdefs
 #################################
 
 virtual_vacation:
   driver = accept
   domains = +local_domains
   condition = ${if and { {!match {$h_precedence:}{(?i)junk|bulk|list}} \
-                         {!match {$h_auto-submitted:}{(?i)auto-}} \
                          {eq {${lookup mysql{select users.on_vacation from users,domains \
                                 where localpart = '${quote_mysql:$local_part}' \
                                 and domain = '${quote_mysql:$domain}' \
@@ -16,6 +17,12 @@ virtual_vacation:
   no_expn
   unseen
   transport = virtual_vacation_delivery
+  # using local_part_suffixes enables possibility to use user-"something" localparts
+  # which could cause you trouble if you're creating email-adresses with dashes in between.
+  .ifdef VEXIM_LOCALPART_SUFFIX
+    local_part_suffix = VEXIM_LOCALPART_SUFFIX
+    local_part_suffix_optional
+  .endif
 
 virtual_forward:
   driver = redirect
@@ -38,27 +45,54 @@ virtual_forward:
                                 and domain = '${quote_mysql:$domain}' \
                                 and users.on_forward = '1' \
                                 and users.domain_id=domains.domain_id}}}{1} }} {yes}{no} }
+  # using local_part_suffixes enables possibility to use user-"something" localparts
+  # which could cause you trouble if you're creating email-adresses with dashes in between.
+  .ifdef VEXIM_LOCALPART_SUFFIX
+    local_part_suffix = VEXIM_LOCALPART_SUFFIX
+    local_part_suffix_optional
+  .endif
 
-virtual_domains:
+virtual_domains_useralias:
+  debug_print = "R: virtual_domains_useralias for $local_part@$domain"
   driver = redirect
   domains = +local_domains
-  address_data = ${lookup mysql{\
-        select smtp, users.sa_tag*10 AS sa_tag, users.on_spamassassin AND domains.spamassassin AS on_spamassassin, \
+  allow_fail
+  data = ${lookup mysql{select smtp from users,domains \
+	where users.type = 'alias' \
+		and localpart = '${quote_mysql:$local_part}' \
+                and domain = '${quote_mysql:$domain}' \
+                and domains.enabled = '1' \
+                and users.enabled = '1' \
+                and users.domain_id = domains.domain_id}}
+  # using local_part_suffixes enables possibility to use user-"something" localparts
+  # which could cause you trouble if you're creating email-adresses with dashes in between.
+  .ifdef VEXIM_LOCALPART_SUFFIX
+    local_part_suffix = VEXIM_LOCALPART_SUFFIX
+    local_part_suffix_optional
+  .endif
+
+virtual_domains:
+  debug_print = "R: LMTP virtual_user for $local_part@$domain"
+  driver = accept
+  domains = +local_domains
+  address_data = ${lookup mysql{ \
+        select concat_ws('@', localpart, domains.domain), smtp, localpart, users.sa_tag*10 AS sa_tag, users.on_spamassassin AND domains.spamassassin AS on_spamassassin, \
         users.uid AS uid, users.gid AS gid, quota \
         from users,domains \
-        where localpart = '${quote_mysql:$local_part}' \
+        where users.type='local' \
+		and localpart = '${quote_mysql:$local_part}' \
                 and domain = '${quote_mysql:$domain}' \
                 and domains.enabled = '1' \
                 and users.enabled = '1' \
                 and users.domain_id = domains.domain_id}{$value}fail}
-  allow_fail
-  data = ${extract{smtp}{$address_data}}
+  cannot_route_message = Unknown user
   headers_add = ${if and { \
                     {match{$domain}{$original_domain}} \
                     {match{$local_part}{$original_local_part}} \
                     {>={$spam_score_int}{${extract{sa_tag}{$address_data}}}} \
                     {eq{1}{${extract{on_spamassassin}{$address_data}}}} \
                     } {X-Spam-Flag: YES\nX-Spam-Score: $acl_m_spam_score\nVEXIM_SPAM_REPORT_HEADER_NAME: $acl_m_spam_report}{} }
+
   # using local_part_suffixes enables possibility to use user-"something" localparts
   # which could cause you trouble if you're creating email-adresses with dashes in between.
   .ifdef VEXIM_LOCALPART_SUFFIX
@@ -66,9 +100,11 @@ virtual_domains:
     local_part_suffix_optional
   .endif
   retry_use_local_part
-  file_transport = virtual_delivery
-  reply_transport = address_reply
-  pipe_transport = address_pipe
+  .ifdef LMTP_COMMAND LMTP_SOCKET
+    transport = virtual_delivery_lmtp
+  .else
+    transport = virtual_delivery
+  .endif
 
 # A group is a list of users
 #
@@ -94,7 +130,7 @@ virtual_dom_groups:
                                        g.enabled = '1' and \
                                        g.is_public = 'N' and c.member_id = u.user_id and \
                                        d.domain_id = u.domain_id and u.enabled = '1' \
-                                       and u.username = '${quote_mysql:$sender_address}' limit 1}}}}
+                                       and concat_ws('@', u.localpart, d.domain) = '${quote_mysql:$sender_address}' }}}}
   data = ${lookup mysql{ \
             select concat_ws('@', u.localpart, d.domain) \
             from domains d, groups g, group_contents c, users u \
@@ -115,7 +151,6 @@ virtual_dom_groups:
   .endif
   retry_use_local_part
   reply_transport = address_reply
-  pipe_transport = address_pipe
 
 virtual_domains_catchall:
   driver = redirect
@@ -125,9 +160,12 @@ virtual_domains_catchall:
                 and domain = '${quote_mysql:$domain}' \
                 and users.domain_id = domains.domain_id}}
   retry_use_local_part
-  file_transport = virtual_delivery
+  .ifdef LMTP_COMMAND LMTP_SOCKET
+    file_transport = virtual_delivery_lmtp
+  .else
+    file_transport = virtual_delivery
+  .endif
   reply_transport = address_reply
-  pipe_transport = address_pipe_catchall
 
 virtual_domain_alias:
   driver = redirect
@@ -137,3 +175,5 @@ virtual_domain_alias:
                 from domains,domainalias where domainalias.alias = '${quote_mysql:$domain}' \
                 and domainalias.domain_id = domains.domain_id}}
   retry_use_local_part
+
+#.endif

--- a/docs/debian-conf.d/transport/30_vexim_virtual_delivery_lmtp
+++ b/docs/debian-conf.d/transport/30_vexim_virtual_delivery_lmtp
@@ -1,0 +1,13 @@
+### transport/30_vexim_virtual_delivery_lmtp
+#######################################
+virtual_delivery_lmtp:
+  debug_print = "T: virtual_delivery_lmtp for $local_part@$domain"
+  driver = lmtp
+#  socket = /var/run/dovecot/lmtp
+  .ifdef LMTP_COMMAND
+    command = LMTP_COMMAND
+  .elifdef LMTP_SOCKET
+    socket = LMTP_SOCKET
+  .endif
+  #maximum number of deliveries per batch, default 1
+  batch_max = 200


### PR DESCRIPTION
I couldn't change PR #247 anymore. Thats why I offer a new PR.

This PR would introduce the LMTP transport which is also in PR #307. The difference is that this version let you define in `lismacrodefs` if you would like to use a socket or a command:

```
#LMTP_COMMAND = /some/local/lmtp/delivery/program
LMTP_SOCKET = /var/run/dovecot/lmtp
```
Fallback is a normal delivery if no LMTP SOCKET/COMMAND is defined.

This PR removes pipe user functionality as discussed in PR #300 from the exim router. It seems we don't have the corresponding transport in our files.

I found and fixed a small bug which occurs in some special cases when using addresses with VEXIM_LOCALPART_SUFFIX.

In a query in the virtual_dom_groups router i fixed: use the email address instead of the username. As in veximpy the username might not be the address.

In `listmacrodefs` I added

```
CHECK_MIME_LOCAL_ACL_FILE = /etc/exim4/vexim-acl-check-mime.conf
```
(used in acl/50_exim4-config_check_mime - at least in my debian setup)